### PR TITLE
Allow xdebug connection

### DIFF
--- a/bin/local-dev/wordpress/Dockerfile
+++ b/bin/local-dev/wordpress/Dockerfile
@@ -106,6 +106,4 @@ COPY config/php/* /usr/local/etc/php/conf.d/
 
 # Setup xdebug.
 RUN pecl install xdebug; \
-	docker-php-ext-enable xdebug; \
-    echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \
-    echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+	docker-php-ext-enable xdebug;

--- a/bin/local-dev/wordpress/Dockerfile
+++ b/bin/local-dev/wordpress/Dockerfile
@@ -106,4 +106,6 @@ COPY config/php/* /usr/local/etc/php/conf.d/
 
 # Setup xdebug.
 RUN pecl install xdebug; \
-	docker-php-ext-enable xdebug;
+	docker-php-ext-enable xdebug; \
+    echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \
+    echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/bin/local-dev/wordpress/config/php/xdebug.ini
+++ b/bin/local-dev/wordpress/config/php/xdebug.ini
@@ -3,3 +3,5 @@ xdebug.remote_enable = 1
 xdebug.remote_autostart = 1
 xdebug.remote_connect_back = 1
 xdebug.scream = 1
+xdebug.mode = debug
+xdebug.client_host = host.docker.internal


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #88 

Steps:
1. `npm run env:stop`
1. `docker rmi material-design-for-wordpress_wordpress`
1. `npm run start` # rebuild image.
Follow steps to reproduce from https://github.com/material-components/material-design-for-wordpress/issues/88

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/material-components/material-design-for-wordpress/issues) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/material-components/material-design-for-wordpress/contributing.md#scripts).
- [x] My code follows the [Contributing Guidelines](https://github.com/material-components/material-design-for-wordpress/contributing.md) (updates are often made to the guidelines, check it out periodically).
