### PR TITLE
Highlights, Numbers and Features pattern (with icon)

### DIFF
--- a/plugin/php/block-patterns/call-to-action-features.php
+++ b/plugin/php/block-patterns/call-to-action-features.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @package MaterialDesign
+ */
+
+/**
+ * 3 Features with icon and CTA.
+ *
+ * @package MaterialDesign
+ */
+
+return [
+	'title'         => __( 'Features with icon + Call to action (CTA)', 'material-design' ),
+	'content'       => "<!-- wp:group {\"align\":\"wide\"} -->\n<div class=\"wp-block-group alignwide\"><div class=\"wp-block-group__inner-container\"><!-- wp:heading {\"textAlign\":\"center\"} -->\n<h2 class=\"has-text-align-center\">Features</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph {\"align\":\"center\",\"fontSize\":\"medium\"} -->\n<p class=\"has-text-align-center has-medium-font-size\">Lorem ipsum dolor sit amet consectetur adipiscing</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:material/icon {\"iconSize\":\"48\",\"align\":\"center\"} -->\n<div class=\"wp-block-material-icon has-text-align-center\"><i class=\"material-icons md-48\">security</i></div>\n<!-- /wp:material/icon -->\n\n<!-- wp:heading {\"textAlign\":\"center\",\"level\":5} -->\n<h5 class=\"has-text-align-center\">Feature 1</h5>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph {\"align\":\"center\"} -->\n<p class=\"has-text-align-center\">Arcu fusce convallis quam pharetra suspendisse porta auctor, fames quis sollicitudin torquent tempus ullamcor.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:material/buttons {\"align\":\"center\"} -->\n<div class=\"wp-block-material-buttons aligncenter\"><!-- wp:material/button {\"iconPosition\":\"none\"} -->\n<div class=\"wp-block-material-button\" id=\"block-material-button-0\"><button class=\"mdc-button mdc-button--raised\"><div class=\"mdc-button__ripple\"></div><span class=\"mdc-button__label\">Call to action</span></button></div>\n<!-- /wp:material/button --></div>\n<!-- /wp:material/buttons -->\n\n<!-- wp:spacer {\"height\":30} -->\n<div style=\"height:30px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer --></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:material/icon {\"iconSize\":\"48\",\"align\":\"center\"} -->\n<div class=\"wp-block-material-icon has-text-align-center\"><i class=\"material-icons md-48\">web</i></div>\n<!-- /wp:material/icon -->\n\n<!-- wp:heading {\"textAlign\":\"center\",\"level\":5} -->\n<h5 class=\"has-text-align-center\">Feature 2</h5>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph {\"align\":\"center\"} -->\n<p class=\"has-text-align-center\">Quis eros molestie libero porttitor convallis, integer sed ullamcorper nunc pharetra cras vitae nisl inceptos.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:material/buttons {\"align\":\"center\"} -->\n<div class=\"wp-block-material-buttons aligncenter\"><!-- wp:material/button {\"iconPosition\":\"none\"} -->\n<div class=\"wp-block-material-button\" id=\"block-material-button-1\"><button class=\"mdc-button mdc-button--raised\"><div class=\"mdc-button__ripple\"></div><span class=\"mdc-button__label\">Call to action</span></button></div>\n<!-- /wp:material/button --></div>\n<!-- /wp:material/buttons -->\n\n<!-- wp:spacer {\"height\":30} -->\n<div style=\"height:30px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer --></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:material/icon {\"iconSize\":\"48\",\"align\":\"center\"} -->\n<div class=\"wp-block-material-icon has-text-align-center\"><i class=\"material-icons md-48\">offline_bolt</i></div>\n<!-- /wp:material/icon -->\n\n<!-- wp:heading {\"textAlign\":\"center\",\"level\":5} -->\n<h5 class=\"has-text-align-center\">Feature 3</h5>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph {\"align\":\"center\"} -->\n<p class=\"has-text-align-center\">Placerat aptent ullamcorper vestibulum netus magnis eros id mauris, curae rutrum inceptos eleifend.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:material/buttons {\"align\":\"center\"} -->\n<div class=\"wp-block-material-buttons aligncenter\"><!-- wp:material/button {\"iconPosition\":\"none\"} -->\n<div class=\"wp-block-material-button\" id=\"block-material-button-2\"><button class=\"mdc-button mdc-button--raised\"><div class=\"mdc-button__ripple\"></div><span class=\"mdc-button__label\">Call to Action</span></button></div>\n<!-- /wp:material/button --></div>\n<!-- /wp:material/buttons -->\n\n<!-- wp:spacer {\"height\":30} -->\n<div style=\"height:30px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer --></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns --></div></div>\n<!-- /wp:group -->",
+	'viewportWidth' => 800,
+	'categories'    => [ 'material', 'buttons', 'header' ],
+	'description'   => __( '3 features with icon + call to action', 'material-design' ),
+];

--- a/plugin/php/block-patterns/highlights.php
+++ b/plugin/php/block-patterns/highlights.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @package MaterialDesign
+ */
+
+/**
+ * Highlights with list items and icons.
+ *
+ * @package MaterialDesign
+ */
+
+return [
+	'title'         => __( 'Highlights', 'material-design' ),
+	'content'       => "<!-- wp:group {\"align\":\"wide\"} -->\n<div class=\"wp-block-group alignwide\"><div class=\"wp-block-group__inner-container\"><!-- wp:columns {\"verticalAlignment\":null} -->\n<div class=\"wp-block-columns\"><!-- wp:column {\"verticalAlignment\":\"top\",\"width\":\"30%\"} -->\n<div class=\"wp-block-column is-vertically-aligned-top\" style=\"flex-basis:30%\"><!-- wp:heading {\"level\":3} -->\n<h3>Highlights</h3>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Amet consectetur adipiscing elit fermentum, quis bibendum pretium sociis eros per habitasse, tempus conubia commodo enim urna malesuada placerat.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:material/buttons -->\n<div class=\"wp-block-material-buttons\"><!-- wp:material/button {\"iconPosition\":\"none\"} -->\n<div class=\"wp-block-material-button\" id=\"block-material-button-0\"><button class=\"mdc-button mdc-button--raised\"><div class=\"mdc-button__ripple\"></div><span class=\"mdc-button__label\">Get started</span></button></div>\n<!-- /wp:material/button --></div>\n<!-- /wp:material/buttons -->\n\n<!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"width\":\"5%\"} -->\n<div class=\"wp-block-column\" style=\"flex-basis:5%\"></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:spacer {\"height\":40} -->\n<div style=\"height:40px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer -->\n\n<!-- wp:material/icon {\"iconSize\":\"48\"} -->\n<div class=\"wp-block-material-icon\"><i class=\"material-icons md-48\">lightbulb_outline</i></div>\n<!-- /wp:material/icon -->\n\n<!-- wp:heading {\"level\":5} -->\n<h5>List item</h5>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Dolor sit amet consectetur adipiscing elit ullamcorper, dictumst ultrices rutrum malesuada turpis pretium rhoncus vitae tempor.</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:spacer {\"height\":40} -->\n<div style=\"height:40px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer -->\n\n<!-- wp:material/icon {\"iconSize\":\"48\"} -->\n<div class=\"wp-block-material-icon\"><i class=\"material-icons md-48\">lightbulb_outline</i></div>\n<!-- /wp:material/icon -->\n\n<!-- wp:heading {\"level\":5} -->\n<h5>List item</h5>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Dolor sit amet consectetur adipiscing elit ullamcorper, dictumst ultrices rutrum malesuada turpis pretium rhoncus vitae tempor.</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->\n\n<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:spacer {\"height\":40} -->\n<div style=\"height:40px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer -->\n\n<!-- wp:material/icon {\"iconSize\":\"48\"} -->\n<div class=\"wp-block-material-icon\"><i class=\"material-icons md-48\">spa</i></div>\n<!-- /wp:material/icon -->\n\n<!-- wp:heading {\"level\":5} -->\n<h5>List item</h5>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Dolor sit amet consectetur adipiscing elit ullamcorper, dictumst ultrices rutrum malesuada turpis pretium rhoncus vitae tempor.</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:column -->\n\n<!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:spacer {\"height\":40} -->\n<div style=\"height:40px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer -->\n\n<!-- wp:material/icon {\"iconSize\":\"48\"} -->\n<div class=\"wp-block-material-icon\"><i class=\"material-icons md-48\">spa</i></div>\n<!-- /wp:material/icon -->\n\n<!-- wp:heading {\"level\":5} -->\n<h5>List item</h5>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Dolor sit amet consectetur adipiscing elit ullamcorper, dictumst ultrices rutrum malesuada turpis pretium rhoncus vitae tempor.</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns --></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns --></div></div>\n<!-- /wp:group -->",
+	'viewportWidth' => 800,
+	'categories'    => [ 'material', 'header' ],
+	'description'   => __( 'Highlights with list items with icons.', 'material-design' ),
+];

--- a/plugin/php/block-patterns/numbers.php
+++ b/plugin/php/block-patterns/numbers.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @package MaterialDesign
+ */
+
+/**
+ * Numbers with icons for statistic.
+ *
+ * @package MaterialDesign
+ */
+
+return [
+	'title'         => __( 'Numbers', 'material-design' ),
+	'content'       => "<!-- wp:group {\"align\":\"wide\"} -->\n<div class=\"wp-block-group alignwide\"><div class=\"wp-block-group__inner-container\"><!-- wp:heading {\"textAlign\":\"center\"} -->\n<h2 class=\"has-text-align-center\">Numbers</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph {\"align\":\"center\",\"style\":{\"typography\":{\"fontSize\":24}}} -->\n<p class=\"has-text-align-center\" style=\"font-size:24px\">Some count that matters</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column {\"verticalAlignment\":\"center\"} -->\n<div class=\"wp-block-column is-vertically-aligned-center\"><!-- wp:material/icon {\"iconSize\":\"36\",\"align\":\"center\"} -->\n<div class=\"wp-block-material-icon has-text-align-center\"><i class=\"material-icons md-36\">thumb_up_off_alt</i></div>\n<!-- /wp:material/icon -->\n\n<!-- wp:heading {\"textAlign\":\"center\",\"level\":3} -->\n<h3 class=\"has-text-align-center\">10k+</h3>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph {\"align\":\"center\"} -->\n<p class=\"has-text-align-center\">Sit amet consectetur adipiscing elit dui, diam nam facilisis</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:spacer {\"height\":30} -->\n<div style=\"height:30px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer --></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"verticalAlignment\":\"center\"} -->\n<div class=\"wp-block-column is-vertically-aligned-center\"><!-- wp:material/icon {\"iconSize\":\"36\",\"align\":\"center\"} -->\n<div class=\"wp-block-material-icon has-text-align-center\"><i class=\"material-icons md-36\">monetization_on</i></div>\n<!-- /wp:material/icon -->\n\n<!-- wp:heading {\"textAlign\":\"center\",\"level\":3} -->\n<h3 class=\"has-text-align-center\">200%</h3>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph {\"align\":\"center\"} -->\n<p class=\"has-text-align-center\">Sit amet consectetur adipiscing elit dui, diam nam facilisis</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:spacer {\"height\":30} -->\n<div style=\"height:30px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer --></div>\n<!-- /wp:column -->\n\n<!-- wp:column {\"verticalAlignment\":\"center\"} -->\n<div class=\"wp-block-column is-vertically-aligned-center\"><!-- wp:material/icon {\"iconSize\":\"36\",\"align\":\"center\"} -->\n<div class=\"wp-block-material-icon has-text-align-center\"><i class=\"material-icons md-36\">file_download</i></div>\n<!-- /wp:material/icon -->\n\n<!-- wp:heading {\"textAlign\":\"center\",\"level\":3} -->\n<h3 class=\"has-text-align-center\">2.5M</h3>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph {\"align\":\"center\"} -->\n<p class=\"has-text-align-center\">Sit amet consectetur adipiscing elit dui, diam nam facilisis</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:spacer {\"height\":30} -->\n<div style=\"height:30px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer --></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->\n\n<!-- wp:material/buttons {\"align\":\"center\"} -->\n<div class=\"wp-block-material-buttons aligncenter\"><!-- wp:material/button {\"iconPosition\":\"none\"} -->\n<div class=\"wp-block-material-button\" id=\"block-material-button-2\"><button class=\"mdc-button mdc-button--raised\"><div class=\"mdc-button__ripple\"></div><span class=\"mdc-button__label\">GET STARTED</span></button></div>\n<!-- /wp:material/button --></div>\n<!-- /wp:material/buttons --></div></div>\n<!-- /wp:group -->", // phpcs:ignore WordPressVIPMinimum.Security.Mustache.OutputNotation
+	'viewportWidth' => 800,
+	'categories'    => [ 'material', 'buttons', 'header' ],
+	'description'   => __( 'Numbers with icons for statistic', 'material-design' ),
+];

--- a/plugin/php/class-block-patterns.php
+++ b/plugin/php/class-block-patterns.php
@@ -77,6 +77,7 @@ class Block_Patterns {
 			'features-list',
 			'logos',
 			'single-feature',
+			'call-to-action-features',
 		];
 
 		foreach ( $patterns as $pattern ) {

--- a/plugin/php/class-block-patterns.php
+++ b/plugin/php/class-block-patterns.php
@@ -78,6 +78,7 @@ class Block_Patterns {
 			'logos',
 			'single-feature',
 			'call-to-action-features',
+			'numbers',
 		];
 
 		foreach ( $patterns as $pattern ) {

--- a/plugin/php/class-block-patterns.php
+++ b/plugin/php/class-block-patterns.php
@@ -79,6 +79,7 @@ class Block_Patterns {
 			'single-feature',
 			'call-to-action-features',
 			'numbers',
+			'highlights',
 		];
 
 		foreach ( $patterns as $pattern ) {

--- a/plugin/tests/phpunit/php/class-test-block-patterns.php
+++ b/plugin/tests/phpunit/php/class-test-block-patterns.php
@@ -39,8 +39,11 @@ class Test_Block_Patterns extends \WP_UnitTestCase {
 		'button',
 		'call-to-action',
 		'call-to-action-benefits',
+		'call-to-action-features',
 		'features-list',
+		'highlights',
 		'logos',
+		'numbers',
 		'single-feature',
 	];
 


### PR DESCRIPTION
## Summary

#### Highlights
- Uses h3 for title. 
- Uses 40px spacer above each list item to match with h3 padding.
- Uses h5 has item heading. 
- Uses 5% width column for space between highlight title and items.

#### Numbers
- Uses h2 for title. 
- Uses h3 for item title. 
- Uses 30px spacer below each column for space in mobile.

#### Features
- Uses h2 for title. 
- Uses h5 for item title.
- Uses 30px spacer below each column for space in mobile.

### Screenshots: 
<details><summary>Desktop</summary>
<p>

![localhost_8088_2021_04_29_highligt-test_](https://user-images.githubusercontent.com/5015489/116646303-391f2480-a967-11eb-9fee-c6ca5d0d4fef.png)

</p>
</details>

<details><summary>Mobile</summary>
<p>

![localhost_8088_2021_04_29_highligt-test_(iPhone X)](https://user-images.githubusercontent.com/5015489/116646374-6370e200-a967-11eb-8f1d-ff5a2eef12ac.png)

</p>
</details>
Mobile:


<!-- Please reference the issue this PR addresses. -->
Fixes #41
Fixes #42
Fixes #103
## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/material-components/material-design-for-wordpress/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing/engineering.md#tests).
- [x] My code follows the [Contributing Guidelines](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing.md) (updates are often made to the guidelines, check it out periodically).
