### PR TITLE
Kses: Allow required attribute in textarea

### DIFF
--- a/plugin/php/blocks/class-contact-form-block.php
+++ b/plugin/php/blocks/class-contact-form-block.php
@@ -425,6 +425,10 @@ class Contact_Form_Block extends Module_Base {
 			'data-label'      => true,
 		];
 
+		if ( isset( $tags['textarea'] ) ) {
+			$tags['textarea']['required'] = true;
+		}
+
 		return $tags;
 	}
 }


### PR DESCRIPTION
## Summary
- Insert contact form pattern.
- From frontend try submitting form without filling textarea.

<img width="946" alt="image" src="https://user-images.githubusercontent.com/5015489/116980961-880ce700-ace4-11eb-97d8-dd090b687e02.png">

<!-- Please reference the issue this PR addresses. -->
See #105

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/material-components/material-design-for-wordpress/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing.md) (updates are often made to the guidelines, check it out periodically).
