### PR TITLE
Use JS to override global style

### DIFF
--- a/plugin/assets/css/src/customize-controls.css
+++ b/plugin/assets/css/src/customize-controls.css
@@ -50,7 +50,7 @@
 		content: "\f460" !important;
 	}
 
-	& .customize-section-description-container {
+	& .customize-section-description-container .customize-section-title {
 		display: none;
 	}
 }

--- a/plugin/assets/src/block-editor/blocks/card/index.js
+++ b/plugin/assets/src/block-editor/blocks/card/index.js
@@ -27,7 +27,8 @@ import edit from './edit';
 import save from './save';
 import metadata from './block.json';
 import { example } from './example';
-
+import { isDefaultCardStyleOutlined } from '../../utils';
+metadata.attributes.outlined.default = isDefaultCardStyleOutlined();
 const { name } = metadata;
 
 export { metadata, name };

--- a/plugin/assets/src/block-editor/blocks/cards-collection/index.js
+++ b/plugin/assets/src/block-editor/blocks/cards-collection/index.js
@@ -27,9 +27,11 @@ import edit from './edit';
 import save from './save';
 import { example } from './example';
 import metadata from './block.json';
+import { isDefaultCardStyleOutlined } from '../../utils';
 
 const { name } = metadata;
 
+metadata.attributes.outlined.default = isDefaultCardStyleOutlined();
 export { metadata, name };
 
 /**

--- a/plugin/assets/src/block-editor/blocks/contact-form/index.js
+++ b/plugin/assets/src/block-editor/blocks/contact-form/index.js
@@ -25,6 +25,9 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import save from './save';
 import metadata from './block.json';
+import { isDefaultTextFieldStyleOutlined } from '../../utils';
+
+metadata.attributes.outlined.default = isDefaultTextFieldStyleOutlined();
 
 const { name } = metadata;
 

--- a/plugin/assets/src/block-editor/blocks/hand-picked-posts/index.js
+++ b/plugin/assets/src/block-editor/blocks/hand-picked-posts/index.js
@@ -27,6 +27,8 @@ import metadata from './block.json';
 
 const { name } = metadata;
 
+import { isDefaultCardStyleOutlined } from '../../utils';
+metadata.attributes.outlined.default = isDefaultCardStyleOutlined();
 export { metadata, name };
 
 /**

--- a/plugin/assets/src/block-editor/blocks/recent-posts/index.js
+++ b/plugin/assets/src/block-editor/blocks/recent-posts/index.js
@@ -25,9 +25,10 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import metadata from './block.json';
 import { example } from './example';
+import { isDefaultCardStyleOutlined } from '../../utils';
 
 const { name } = metadata;
-
+metadata.attributes.outlined.default = isDefaultCardStyleOutlined();
 export { metadata, name };
 
 /**

--- a/plugin/assets/src/block-editor/utils/is-default-card-style-outlined.js
+++ b/plugin/assets/src/block-editor/utils/is-default-card-style-outlined.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
-export { default as findIcon } from './find-icon';
-export { default as getConfig } from './get-config';
-export { default as getIconName } from './get-icon-name';
-export { default as isDefaultCardStyleOutlined } from './is-default-card-style-outlined';
-export { default as isDefaultTextFieldStyleOutlined } from './is-default-text-field-outlined';
+import { getConfig } from './index';
+
+/**
+ * Whether global card style outlined.
+ *
+ * @return {boolean} Is outlined.
+ */
+export default () =>
+	// eslint-disable-next-line camelcase
+	getConfig( 'defaults' )?.globalStyle?.card_style === 'outlined';

--- a/plugin/assets/src/block-editor/utils/is-default-text-field-outlined.js
+++ b/plugin/assets/src/block-editor/utils/is-default-text-field-outlined.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
-export { default as findIcon } from './find-icon';
-export { default as getConfig } from './get-config';
-export { default as getIconName } from './get-icon-name';
-export { default as isDefaultCardStyleOutlined } from './is-default-card-style-outlined';
-export { default as isDefaultTextFieldStyleOutlined } from './is-default-text-field-outlined';
+import { getConfig } from './index';
+
+/**
+ * Whether global text input style outlined.
+ *
+ * @return {boolean} Is outlined.
+ */
+export default () =>
+	// eslint-disable-next-line camelcase
+	getConfig( 'defaults' )?.globalStyle?.text_field_style === 'outlined';

--- a/plugin/assets/src/front-end/global-style.js
+++ b/plugin/assets/src/front-end/global-style.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* global materialDesign */
+
+const getOutlineClassHandler = ( style, classSelector, outlinedClass ) => {
+	return () => {
+		// eslint-disable-next-line camelcase
+		if ( style === 'inherit' || ! style ) {
+			return;
+		}
+		const list = document.querySelectorAll( classSelector );
+		list.forEach( item => {
+			const hasOutlined = item.classList.contains( outlinedClass );
+			if ( style === 'outlined' && ! hasOutlined ) {
+				item.classList.add( outlinedClass );
+			} else if ( style !== 'outlined' && hasOutlined ) {
+				item.classList.remove( outlinedClass );
+			}
+		} );
+	};
+};
+
+const initCardGlobalStyle = () => {
+	getOutlineClassHandler(
+		// eslint-disable-next-line camelcase
+		materialDesign?.globalStyle?.card_style,
+		'.mdc-card',
+		'mdc-card--outlined'
+	)();
+};
+
+const initTextFieldGlobalStyle = () => {
+	getOutlineClassHandler(
+		// eslint-disable-next-line camelcase
+		materialDesign?.globalStyle?.text_field_style,
+		'.mdc-text-field',
+		'mdc-text-field--outlined'
+	)();
+};
+
+export const initGlobalStyle = () => {
+	initCardGlobalStyle();
+	initTextFieldGlobalStyle();
+};

--- a/plugin/assets/src/front-end/index.js
+++ b/plugin/assets/src/front-end/index.js
@@ -27,8 +27,10 @@ import {
 	initToolTips,
 } from '../common/mdc-components-init';
 import { initContactForm } from './contact-form';
+import { initGlobalStyle } from './global-style';
 
 addEventListener( 'DOMContentLoaded', () => {
+	initGlobalStyle();
 	initButtons();
 	initLists();
 	initTabBar();

--- a/plugin/php/class-block-types.php
+++ b/plugin/php/class-block-types.php
@@ -86,19 +86,27 @@ class Block_Types {
 
 		$blocks_dir    = $this->plugin->dir_path . '/assets/js/blocks/';
 		$block_folders = [
-			'button',
-			'card',
-			'cards-collection',
-			'contact-form',
-			'data-table',
-			'hand-picked-posts',
-			'image-list',
-			'list',
-			'recent-posts',
-			'tab-bar',
+			'button'            => [],
+			'card'              => [
+				'outlined' => [ $this, 'is_default_card_style_outlined' ],
+			],
+			'cards-collection'  => [
+				'outlined' => [ $this, 'is_default_card_style_outlined' ],
+			],
+			'contact-form'      => [
+				'outlined' => [ $this, 'is_default_text_field_style_outlined' ],
+			],
+			'data-table'        => [],
+			'hand-picked-posts' => [],
+			'image-list'        => [],
+			'list'              => [],
+			'recent-posts'      => [
+				'outlined' => [ $this, 'is_default_card_style_outlined' ],
+			],
+			'tab-bar'           => [],
 		];
 
-		foreach ( $block_folders as $block_name ) {
+		foreach ( $block_folders as $block_name => $override_attributes ) {
 			$block_json_file = $blocks_dir . $block_name . '/block.json';
 			if ( ! file_exists( $block_json_file ) ) {
 				continue;
@@ -107,6 +115,10 @@ class Block_Types {
 			$metadata = json_decode( file_get_contents( $block_json_file ), true ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
 			if ( ! is_array( $metadata ) || ! $metadata['name'] ) {
 				continue;
+			}
+
+			foreach ( $override_attributes as $attr_key => $attr ) {
+				$metadata['attributes'][ $attr_key ]['default'] = call_user_func( $attr );
 			}
 
 			$metadata['editor_script'] = 'material-block-editor-js';
@@ -213,8 +225,9 @@ class Block_Types {
 			'tab_bar_preview'          => $this->plugin->asset_url( 'assets/images/preview/tab-bar.jpg' ),
 			'contact_form_preview'     => $this->plugin->asset_url( 'assets/images/preview/contact-form.jpg' ),
 			'defaults'                 => [
-				'blocks' => $this->get_block_defaults(),
-				'colors' => $this->get_color_defaults(),
+				'blocks'      => $this->get_block_defaults(),
+				'colors'      => $this->get_color_defaults(),
+				'globalStyle' => $this->get_global_styles(),
 			],
 			'customizerUrls'           => [
 				'colors' => add_query_arg( 'autofocus[section]', $slug . '_colors', $customizer_url ),
@@ -306,6 +319,51 @@ class Block_Types {
 		};
 
 		return $defaults;
+	}
+
+	/**
+	 * Get global style configs.
+	 *
+	 * @param string $key get single value.
+	 *
+	 * @return array|string
+	 */
+	public function get_global_styles( $key = null ) {
+		$defaults = [];
+		$controls = $this->plugin->customizer_controls;
+
+		foreach ( $controls->get_global_style_controls() as $control ) {
+			$value = $controls->get_option( $control['id'] );
+			if ( ! empty( $value ) ) {
+				$defaults[ $control['id'] ] = $value;
+			}
+		}
+
+		return ( $key ? ( isset( $defaults[ $key ] ) ? $defaults[ $key ] : '' ) : $defaults );
+	}
+
+	/**
+	 * Whether default card style is outlined.
+	 *
+	 * @return bool
+	 */
+	public function is_default_card_style_outlined() {
+		$style = $this->get_global_styles();
+		$style = isset( $style['card_style'] ) ? $style['card_style'] : '';
+
+		return 'outlined' === $style;
+	}
+
+	/**
+	 * Whether default text field style is outlined.
+	 *
+	 * @return bool
+	 */
+	public function is_default_text_field_style_outlined() {
+		$style = $this->get_global_styles();
+		$style = isset( $style['text_field_style'] ) ? $style['text_field_style'] : '';
+
+		return 'outlined' === $style;
 	}
 
 	/**

--- a/plugin/php/class-plugin.php
+++ b/plugin/php/class-plugin.php
@@ -209,7 +209,10 @@ class Plugin extends Plugin_Base {
 		);
 
 		$material_design_recaptcha_site_key = get_option( 'material_design_recaptcha_site_key', '' );
-		$wp_localized_script_data           = [ 'ajax_url' => admin_url( 'admin-ajax.php' ) ];
+		$wp_localized_script_data           = [
+			'ajax_url'    => admin_url( 'admin-ajax.php' ),
+			'globalStyle' => $this->block_types->get_global_styles(),
+		];
 
 		if ( function_exists( 'has_block' ) && has_block( 'material/contact-form' ) && ! empty( $material_design_recaptcha_site_key ) ) {
 			wp_enqueue_script(

--- a/plugin/php/customizer/class-controls.php
+++ b/plugin/php/customizer/class-controls.php
@@ -139,7 +139,7 @@ class Controls extends Module_Base {
 			'global-setting' => [
 				'label'       => __( 'Global Styles', 'material-design' ),
 				'priority'    => 300,
-				'description' => esc_html__( 'Global styles will be applied to any new and existing static block using the default style. This will not affect any local style overrides for supported blocks.', 'material-design' ),
+				'description' => esc_html__( 'Global styles will be applied in all pages including custom templates.', 'material-design' ),
 			],
 		];
 
@@ -552,8 +552,9 @@ class Controls extends Module_Base {
 				'id'      => 'card_style',
 				'label'   => esc_html__( 'Cards', 'material-design' ),
 				'type'    => 'radio',
-				'default' => 'elevated',
+				'default' => 'inherit',
 				'choices' => [
+					'inherit'  => esc_html__( 'Inherit', 'material-design' ),
 					'elevated' => esc_html__( 'Elevated', 'material-design' ),
 					'outlined' => esc_html__( 'Outlined', 'material-design' ),
 				],
@@ -562,8 +563,9 @@ class Controls extends Module_Base {
 				'id'      => 'text_field_style',
 				'label'   => esc_html__( 'Text field', 'material-design' ),
 				'type'    => 'radio',
-				'default' => 'elevated',
+				'default' => 'inherit',
 				'choices' => [
+					'inherit'  => esc_html__( 'Inherit', 'material-design' ),
 					'elevated' => esc_html__( 'Elevated', 'material-design' ),
 					'outlined' => esc_html__( 'Outlined', 'material-design' ),
 				],

--- a/plugin/php/templates/partials/single-post.php
+++ b/plugin/php/templates/partials/single-post.php
@@ -30,7 +30,7 @@ defined( 'ABSPATH' ) || exit;
 $attributes     = isset( $attributes ) ? $attributes : [];
 $style          = isset( $attributes['style'] ) ? $attributes['style'] : 'masonry';
 $columns        = absint( isset( $attributes['columns'] ) ? $attributes['columns'] : 3 );
-$outlined       = isset( $attributes['outlined'] ) ? $attributes['outlined'] : false;
+$outlined       = ! empty( $attributes['outlined'] ) ? $attributes['outlined'] : \MaterialDesign\Plugin\get_plugin_instance()->block_types->get_global_styles( 'card_style' ) === 'outlined';
 $layout         = isset( $attributes['contentLayout'] ) ? $attributes['contentLayout'] : 'text-above-media';
 $featured_image = isset( $attributes['displayFeaturedImage'] ) ? $attributes['displayFeaturedImage'] : true;
 

--- a/plugin/tests/phpunit/php/class-test-block-types.php
+++ b/plugin/tests/phpunit/php/class-test-block-types.php
@@ -84,13 +84,27 @@ class Test_Block_Types extends \WP_UnitTestCase {
 			}
 		);
 
+		update_option(
+			'material_design',
+			[
+				'text_field_style' => 'elevated',
+				'card_style'       => 'outlined',
+			]
+		);
+
 		$block_types->register_blocks();
 
 		$blocks = \WP_Block_Type_Registry::get_instance()->get_all_registered();
 
+		$card_blocks = [
+			'card',
+			'cards-collection',
+			'recent-posts',
+		];
+
 		array_walk(
 			self::$blocks,
-			function( $block_name ) use ( $blocks ) {
+			function( $block_name ) use ( $blocks, $card_blocks ) {
 				// Assert the block is registered.
 				$this->assertTrue( array_key_exists( 'material/' . $block_name, $blocks ) );
 
@@ -103,6 +117,10 @@ class Test_Block_Types extends \WP_UnitTestCase {
 				$block_json   = $block_folder . '/block.json';
 				$metadata     = json_decode( file_get_contents( $block_json ), true ); // phpcs:ignore
 
+				// We have set outlined to true for card blocks.
+				if ( in_array( $block_name, $card_blocks, true ) ) {
+					$metadata['attributes']['outlined']['default'] = true;
+				}
 				$this->assertEquals( $metadata['category'], $block->category );
 				$this->assertEquals( $metadata['attributes'], $block->attributes );
 
@@ -137,6 +155,7 @@ class Test_Block_Types extends \WP_UnitTestCase {
 
 		// Assert inline js vars contains ajax url data.
 		$this->assertRegexp( '/ajax_url/', $inline_js );
+		$this->assertRegexp( '/globalStyle/', $inline_js );
 	}
 
 	/**

--- a/plugin/tests/phpunit/php/customizer/class-test-controls.php
+++ b/plugin/tests/phpunit/php/customizer/class-test-controls.php
@@ -209,14 +209,15 @@ class Test_Controls extends \WP_Ajax_UnitTestCase {
 
 		// Set up the expectation for the add_section() method
 		// to be called 5 times, once for each section.
-		$this->wp_customize->expects( $this->exactly( 5 ) )
+		$this->wp_customize->expects( $this->exactly( 6 ) )
 			->method( 'add_section' )
 			->withConsecutive(
 				[ $this->equalTo( "{$controls->slug}_style" ) ],
 				[ $this->equalTo( "{$controls->slug}_colors" ) ],
 				[ $this->equalTo( "{$controls->slug}_typography" ) ],
 				[ $this->equalTo( "{$controls->slug}_corner_styles" ) ],
-				[ $this->equalTo( $icons_section ) ]
+				[ $this->equalTo( $icons_section ) ],
+				[ $this->equalTo( "{$controls->slug}_global-setting" ) ]
 			);
 
 		$controls->add_sections();

--- a/theme/comments.php
+++ b/theme/comments.php
@@ -37,10 +37,12 @@ if ( post_password_required() ) {
 	return;
 }
 
-$commenter = wp_get_current_commenter();
-$style     = get_theme_mod( 'comment_fields_style', 'outlined' );
+$commenter    = wp_get_current_commenter();
+$style        = get_theme_mod( 'comment_fields_style', 'outlined' );
+$global_style = get_material_global_style( 'text_field_style' );
 
-$classes  = 'outlined' === $style ? 'mdc-text-field--outlined mdc-text-field--no-label' : 'mdc-text-field--filled';
+$classes = in_array( 'outlined', [ $style, $global_style ], true ) ? 'mdc-text-field--outlined mdc-text-field--no-label' : 'mdc-text-field--filled';
+
 $req      = get_option( 'require_name_email' );
 $html_req = ( $req ? " required='required'" : '' );
 

--- a/theme/functions.php
+++ b/theme/functions.php
@@ -197,6 +197,21 @@ function material_is_plugin_active() {
 }
 
 /**
+ * Get material global style.
+ *
+ * @param string $key setting to get.
+ */
+function get_material_global_style( $key ) {
+	if ( material_is_plugin_active() ) {
+		$instance = \MaterialDesign\Plugin\get_plugin_instance();
+		if ( property_exists( $instance, 'block_types' ) && method_exists( $instance->block_types, 'get_global_styles' ) ) {
+			return $instance->block_types->get_global_styles( $key );
+		}
+	}
+	return '';
+}
+
+/**
  * Custom template tags for this theme.
  */
 require get_template_directory() . '/inc/template-tags.php';

--- a/theme/searchform.php
+++ b/theme/searchform.php
@@ -25,11 +25,11 @@
 
 $search_id       = uniqid( 'search-' );
 $search_label_id = uniqid( 'search-label-' );
-
+$global_style    = get_material_global_style( 'text_field_style' );
 ?>
 
 <form class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>" method="get" role="search" id="<?php echo esc_attr( $search_id ); ?>">
-	<label class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-trailing-icon">
+	<label class="mdc-text-field <?php echo 'outlined' === $global_style ? 'mdc-text-field--outlined ' : ''; ?> mdc-text-field--with-trailing-icon">
 		<input class="mdc-text-field__input" type="text" aria-labelledby="<?php echo esc_attr( $search_label_id ); ?>" name="s" value="<?php echo get_search_query(); ?>">
 		<i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">search</i>
 		<div class="mdc-notched-outline">

--- a/theme/template-parts/content.php
+++ b/theme/template-parts/content.php
@@ -29,7 +29,7 @@ $show_comments = get_theme_mod( 'archive_comments', true );
 $show_author   = get_theme_mod( 'archive_author', true );
 $show_excerpt  = get_theme_mod( 'archive_excerpt', true );
 $show_date     = get_theme_mod( 'archive_date', true );
-$classes       = get_theme_mod( 'archive_outlined', false ) ? 'mdc-card--outlined' : '';
+$classes       = get_theme_mod( 'archive_outlined' ) || ( get_material_global_style( 'card_style' ) === 'outlined' ) ? 'mdc-card--outlined' : '';
 ?>
 
 <div id="<?php the_ID(); ?>" <?php post_class( "mdc-card post-card $classes" ); ?>>

--- a/theme/template-parts/search-archive.php
+++ b/theme/template-parts/search-archive.php
@@ -22,12 +22,13 @@
  *
  * @package MaterialDesign
  */
-
-$search_id = uniqid( 'search-' );
+global $material_design_plugin;
+$search_id    = uniqid( 'search-' );
+$global_style = get_material_global_style( 'text_field_style' );
 ?>
 
 <form class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>" method="get" id="<?php echo esc_attr( $search_id ); ?>">
-	<div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-trailing-icon">
+	<div class="mdc-text-field <?php echo 'outlined' === $global_style ? 'mdc-text-field--outlined ' : ''; ?> mdc-text-field--with-trailing-icon">
 		<i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0">search</i>
 		<input class="mdc-text-field__input" id="text-field-hero-input" name="s">
 		<div class="mdc-notched-outline">


### PR DESCRIPTION
## Summary
- Adds setting in plugin for global card and text field.
- Sets default block value based on setting in Gutenberg editor for card and text.
- Uses JS to toggle class to outlined or elevated for card and text field when inherited is not selected.
- Global setting also changes material theme's default text field like search.
<!-- Please reference the issue this PR addresses. -->
See #59 #60

Demo:

https://user-images.githubusercontent.com/5015489/122202434-aefd3200-ceba-11eb-900f-b73d179d946e.mp4


## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/material-components/material-design-for-wordpress/issues) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing/engineering.md#tests).
- [x] My code follows the [Contributing Guidelines](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing.md) (updates are often made to the guidelines, check it out periodically).
