### PR TITLE
Fix WP_Error import

### DIFF
--- a/plugin/php/class-importer.php
+++ b/plugin/php/class-importer.php
@@ -25,7 +25,7 @@
 
 namespace MaterialDesign\Plugin;
 
-use MaterialDesign\Plugin\Plugin;
+use WP_Error;
 
 /**
  * Plugin Importer class.


### PR DESCRIPTION
## Summary
Fixes error of `Uncaught Error: Class 'MaterialDesign\\Plugin\\WP_Error' not found`.

<!-- Please reference the issue this PR addresses. -->
Fixes #

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/material-components/material-design-for-wordpress/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing.md) (updates are often made to the guidelines, check it out periodically).
