### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/plugin/material-design.php
+++ b/plugin/material-design.php
@@ -3,7 +3,7 @@
  * Plugin Name: Material Design
  * Plugin URI: https://github.com/material-components/material-design-for-wordpress
  * Description: The official Material Design plugin for WordPress. Customize your site’s navigation, colors, typography, and shapes, use Material Components, and choose from over 1,000 Google Fonts and Material Design icons. From the team behind Google’s open-source design system.
- * Version: 0.3.1
+ * Version: 0.4.0
  * Requires at least: 5.2
  * Requires PHP:      5.6.20+
  * Author:  Material Design

--- a/plugin/readme.md
+++ b/plugin/readme.md
@@ -8,7 +8,7 @@ The official Material Design plugin for WordPress. Customize your site’s navig
 **Contributors:** [google](https://profiles.wordpress.org/google), [materialdesign](https://profiles.wordpress.org/materialdesign), [xwp](https://profiles.wordpress.org/xwp)
 **Requires at least:** 5.2
 **Tested up to:** 5.8.0
-**Stable tag:** 0.3.1
+**Stable tag:** 0.4.0
 **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
 ## Description ##

--- a/plugin/readme.txt
+++ b/plugin/readme.txt
@@ -2,7 +2,7 @@
 Contributors: google, materialdesign, xwp
 Requires at least: 5.2
 Tested up to: 5.8
-Stable tag: 0.3.1
+Stable tag: 0.4.0
 License: Apache License, Version 2.0
 License URI: https://www.apache.org/licenses/LICENSE-2.0
 Tags: material-design, material-theming, google, blocks, gutenberg, theme-builder, accessibility, dark-mode

--- a/theme/README.md
+++ b/theme/README.md
@@ -7,7 +7,7 @@ The official Material Design Theme for WordPress.
 **Contributors:** [google](https://profiles.wordpress.org/google), [materialdesign](https://profiles.wordpress.org/materialdesign), [xwp](https://profiles.wordpress.org/xwp)
 **Requires at least:** 5.2
 **Tested up to:** 5.8
-**Stable tag:** 0.3.1
+**Stable tag:** 0.4.0
 **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 **Requires PHP:** 5.6
 

--- a/theme/readme.txt
+++ b/theme/readme.txt
@@ -3,7 +3,7 @@ Contributors: google, materialdesign, xwp
 Requires at least: 5.2
 Tested up to: 5.8
 Requires PHP: 5.6
-Stable tag: 0.3.1
+Stable tag: 0.4.0
 License: Apache License, Version 2.0
 License URI: https://www.apache.org/licenses/LICENSE-2.0
 

--- a/theme/style.css
+++ b/theme/style.css
@@ -19,7 +19,7 @@ Theme URI: https://github.com/material-components/material-design-for-wordpress
 Author: Material Design
 Author URI: https://material.io/
 Description: The official Material Design theme for WordPress – from the team behind Google’s open-source design system. Apply Material Design principles and Material Theming to your site, and customize its style. Pair this with the official Material Design for WordPress plugin to customize your site’s navigation, colors, typography, and shapes, use Material Components, and choose from over 1,000 Google Fonts and Material Design icons.
-Version: 0.3.1
+Version: 0.4.0
 License: Apache License, Version 2.0
 License URI: https://www.apache.org/licenses/LICENSE-2.0
 Text Domain: material-design-google


### PR DESCRIPTION
## Version 0.4.0 Dark mode!

For the full list of changes in this release, please see the [Milestone 0.4.0](https://github.com/material-components/material-design-for-wordpress/issues?q=is%3Aissue+milestone%3A0.4.0).

https://user-images.githubusercontent.com/5015489/132191348-a06e9385-e6d2-431a-b5b4-7f263b741d7d.mp4


## Changelog:
-  **Dark mode**:  Pick a dark mode from an existing theme or create your own custom theme and generate a customized dark theme from it.
    - Manually turn on/off dark mode or automatically based on the user's system preference. 
    - Allow user to switch between light and dark mode via switcher.
- Add inline Icon in paragraphs. (https://github.com/material-components/material-design-for-wordpress/issues/79)
- Add meta tag in header (https://github.com/material-components/material-design-for-wordpress/issues/192)
- Fix breaking material list block in WordPress 5.8 (https://github.com/material-components/material-design-for-wordpress/issues/187)
- Color utility conversion (https://github.com/material-components/material-design-for-wordpress/issues/168)
- Add newsletter email signup (https://github.com/material-components/material-design-for-wordpress/issues/161)
- Add warning for bumping the minimum supported version to WordPress 5.6. (https://github.com/material-components/material-design-for-wordpress/issues/179)
## Props
Thanks to the many contributors who made this release possible through work on development, design, testing, project management, and more:

> @emeaguiar, @pbearne, @csossi, @jauyong, @mattchungxwp, @dawidmlynarz, @rodydavis, @PatelUtkarsh

---

- [x] Write a complete description
- [x] Update changelog
- [x] Add contributors
- [ ] Merge & tag a release
