### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/plugin/material-design.php
+++ b/plugin/material-design.php
@@ -3,7 +3,7 @@
  * Plugin Name: Material Design
  * Plugin URI: https://github.com/material-components/material-design-for-wordpress
  * Description: The official Material Design plugin for WordPress. Customize your site’s navigation, colors, typography, and shapes, use Material Components, and choose from over 1,000 Google Fonts and Material Design icons. From the team behind Google’s open-source design system.
- * Version: 0.4.0
+ * Version: 0.4.1
  * Requires at least: 5.2
  * Requires PHP:      5.6.20+
  * Author:  Material Design

--- a/plugin/readme.md
+++ b/plugin/readme.md
@@ -8,7 +8,7 @@ The official Material Design plugin for WordPress. Customize your site’s navig
 **Contributors:** [google](https://profiles.wordpress.org/google), [materialdesign](https://profiles.wordpress.org/materialdesign), [xwp](https://profiles.wordpress.org/xwp)
 **Requires at least:** 5.2
 **Tested up to:** 5.8.1
-**Stable tag:** 0.4.0
+**Stable tag:** 0.4.1
 **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
 ## Description ##

--- a/plugin/readme.txt
+++ b/plugin/readme.txt
@@ -2,7 +2,7 @@
 Contributors: google, materialdesign, xwp
 Requires at least: 5.2
 Tested up to: 5.8.1
-Stable tag: 0.4.0
+Stable tag: 0.4.1
 License: Apache License, Version 2.0
 License URI: https://www.apache.org/licenses/LICENSE-2.0
 Tags: material-design, material-theming, google, blocks, gutenberg, theme-builder, accessibility, dark-mode

--- a/theme/README.md
+++ b/theme/README.md
@@ -7,7 +7,7 @@ The official Material Design Theme for WordPress.
 **Contributors:** [google](https://profiles.wordpress.org/google), [materialdesign](https://profiles.wordpress.org/materialdesign), [xwp](https://profiles.wordpress.org/xwp)
 **Requires at least:** 5.2
 **Tested up to:** 5.8.1
-**Stable tag:** 0.4.0
+**Stable tag:** 0.4.1
 **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 **Requires PHP:** 5.6
 

--- a/theme/readme.txt
+++ b/theme/readme.txt
@@ -3,7 +3,7 @@ Contributors: google, materialdesign, xwp
 Requires at least: 5.2
 Tested up to: 5.8.1
 Requires PHP: 5.6
-Stable tag: 0.4.0
+Stable tag: 0.4.1
 License: Apache License, Version 2.0
 License URI: https://www.apache.org/licenses/LICENSE-2.0
 

--- a/theme/style.css
+++ b/theme/style.css
@@ -19,7 +19,7 @@ Theme URI: https://github.com/material-components/material-design-for-wordpress
 Author: Material Design
 Author URI: https://material.io/
 Description: The official Material Design theme for WordPress – from the team behind Google’s open-source design system. Apply Material Design principles and Material Theming to your site, and customize its style. Pair this with the official Material Design for WordPress plugin to customize your site’s navigation, colors, typography, and shapes, use Material Components, and choose from over 1,000 Google Fonts and Material Design icons.
-Version: 0.4.0
+Version: 0.4.1
 License: Apache License, Version 2.0
 License URI: https://www.apache.org/licenses/LICENSE-2.0
 Text Domain: material-design-google


### PR DESCRIPTION
## Changelog:
- Feature: Allow controlling global settings for card elevation. (https://github.com/material-components/material-design-for-wordpress/issues/60)
- Bump WordPress support to 5.6. (https://github.com/material-components/material-design-for-wordpress/issues/195)
- Color palette jump on color selection. (https://github.com/material-components/material-design-for-wordpress/issues/215)
- Plugin and theme dependency. (https://github.com/material-components/material-design-for-wordpress/issues/183)
- Fix Material list block saving. (https://github.com/material-components/material-design-for-wordpress/issues/61)
- Fix dark mode Gutenberg editor. (https://github.com/material-components/material-design-for-wordpress/issues/214)
- Update settings for card collection block. (https://github.com/material-components/material-design-for-wordpress/issues/61)

## Props 
Thanks to the many contributors who made this release possible through work on development, design, testing, project management, and more:

`@rodydavis, @PatelUtkarsh, @emeaguiar, @csossi, @jauyong, @mattchungxwp`
