### PR TITLE
Add colors in theme.json

### DIFF
--- a/plugin/php/class-plugin.php
+++ b/plugin/php/class-plugin.php
@@ -200,8 +200,8 @@ class Plugin extends Plugin_Base {
 
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_google_fonts' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_front_end_assets' ], 100 );
-		add_action( 'wp_head', [ $this, 'frontend_inline_css' ], 1 );
-		add_action( 'admin_head', [ $this, 'frontend_inline_css' ], 1 );
+		add_action( 'wp_head', [ $this, 'frontend_inline_css' ], 5 );
+		add_action( 'admin_head', [ $this, 'frontend_inline_css' ], 5 );
 		add_action( 'plugin_row_meta', [ $this, 'get_plugin_row_meta' ], 10, 2 );
 	}
 

--- a/plugin/php/customizer/class-controls.php
+++ b/plugin/php/customizer/class-controls.php
@@ -82,6 +82,7 @@ class Controls extends Module_Base {
 		add_action( 'wp_ajax_material_design_notification_dismiss', [ $this, 'notification_dismiss' ] );
 
 		add_filter( 'material_design_customizer_section_args', [ $this, 'filter_style_section' ], 10, 2 );
+		add_filter( 'material_design_theme_colors_additional_controls', [ $this, 'add_additional_theme_color_controls' ], 10 );
 	}
 
 	/**
@@ -1233,6 +1234,8 @@ class Controls extends Module_Base {
 				'a11y_label'           => __( 'On Primary', 'material-design' ),
 				'related_text_setting' => $this->prepare_option_name( 'on_primary_color' ),
 				'css_var'              => '--mdc-theme-primary',
+				'theme_json'           => 'primary',
+				'order'                => 1,
 			],
 			[
 				'id'              => 'on_primary_color',
@@ -1240,6 +1243,8 @@ class Controls extends Module_Base {
 				'a11y_label'      => __( 'On Primary', 'material-design' ),
 				'related_setting' => $this->prepare_option_name( 'primary_color' ),
 				'css_var'         => '--mdc-theme-on-primary',
+				'theme_json'      => 'on-primary',
+				'order'           => 2,
 			],
 			[
 				'id'                   => 'secondary_color',
@@ -1247,6 +1252,8 @@ class Controls extends Module_Base {
 				'a11y_label'           => __( 'On Secondary', 'material-design' ),
 				'related_text_setting' => $this->prepare_option_name( 'on_secondary_color' ),
 				'css_var'              => '--mdc-theme-secondary',
+				'theme_json'           => 'secondary',
+				'order'                => 3,
 			],
 			[
 				'id'              => 'on_secondary_color',
@@ -1254,6 +1261,8 @@ class Controls extends Module_Base {
 				'a11y_label'      => __( 'On Secondary', 'material-design' ),
 				'related_setting' => $this->prepare_option_name( 'secondary_color' ),
 				'css_var'         => '--mdc-theme-on-secondary',
+				'theme_json'      => 'on-secondary',
+				'order'           => 4,
 			],
 			[
 				'id'                   => 'surface_color',
@@ -1261,6 +1270,8 @@ class Controls extends Module_Base {
 				'a11y_label'           => __( 'On Surface', 'material-design' ),
 				'related_text_setting' => $this->prepare_option_name( 'on_surface_color' ),
 				'css_var'              => '--mdc-theme-surface',
+				'theme_json'           => 'surface',
+				'order'                => 5,
 			],
 			[
 				'id'              => 'on_surface_color',
@@ -1268,6 +1279,8 @@ class Controls extends Module_Base {
 				'a11y_label'      => __( 'On Surface', 'material-design' ),
 				'related_setting' => $this->prepare_option_name( 'surface_color' ),
 				'css_var'         => '--mdc-theme-on-surface',
+				'theme_json'      => 'on-surface',
+				'order'           => 6,
 			],
 		];
 	}
@@ -1999,5 +2012,21 @@ class Controls extends Module_Base {
 
 		$this->add_settings( $settings );
 		$this->add_controls( $controls );
+	}
+
+	/**
+	 * Add additional theme colors.
+	 *
+	 * Used for overriding theme json.
+	 *
+	 * @return array[]
+	 */
+	public function add_additional_theme_color_controls() {
+		$colors = $this->get_color_controls();
+		foreach ( $colors as &$color ) {
+			$color['slug'] = $this->prepare_option_name( $color['id'] );
+		}
+
+		return $colors;
 	}
 }

--- a/plugin/php/customizer/class-controls.php
+++ b/plugin/php/customizer/class-controls.php
@@ -878,6 +878,7 @@ class Controls extends Module_Base {
 
 			$color_vars[] = sprintf( '%s: %s;', esc_html( $control['css_var'] ), esc_html( $value ) );
 			$color_vars[] = sprintf( '%s: %s;', esc_html( $control['css_var'] . '-rgb' ), esc_html( $rgb ) );
+			$color_vars[] = sprintf( '%s: %s;', esc_html( sprintf( '--wp--preset--color--%s', $control['theme_json'] ) ), esc_html( $value ) );
 		}
 
 		// Generate additional surface variant vars required by some components.
@@ -990,6 +991,7 @@ class Controls extends Module_Base {
 
 			$dark_mode_vars[] = sprintf( '%s: %s;', esc_html( $control['css_var'] ), esc_html( $value ) );
 			$dark_mode_vars[] = sprintf( '%s: %s;', esc_html( $control['css_var'] . '-rgb' ), esc_html( $rgb ) );
+			$dark_mode_vars[] = sprintf( '%s: %s;', esc_html( sprintf( '--wp--preset--color--%s', $control['theme_json'] ) ), esc_html( $value ) );
 		}
 
 		$glue               = "\n\t\t\t\t";

--- a/plugin/php/customizer/class-controls.php
+++ b/plugin/php/customizer/class-controls.php
@@ -1002,7 +1002,7 @@ class Controls extends Module_Base {
 		$dark_mode_vars     = implode( $glue, $dark_mode_vars );
 
 		$css = "
-			:root {
+			:root, body {
 				/* Theme color vars */
 				{$color_vars}
 
@@ -1030,7 +1030,7 @@ class Controls extends Module_Base {
 		if ( 'inactive' !== $this->get_dark_mode_status() ) {
 			$css .= "
 				@media (prefers-color-scheme: dark) {
-					:root {
+					:root, body {
 						{$dark_mode_vars}
 					}
 				}

--- a/plugin/php/customizer/class-material-color-palette-control.php
+++ b/plugin/php/customizer/class-material-color-palette-control.php
@@ -25,8 +25,6 @@
 
 namespace MaterialDesign\Plugin\Customizer;
 
-use MaterialDesign\Plugin\Helpers;
-
 /**
  * Material color palette control.
  */

--- a/plugin/tests/phpunit/php/customizer/class-test-controls.php
+++ b/plugin/tests/phpunit/php/customizer/class-test-controls.php
@@ -623,7 +623,7 @@ class Test_Controls extends \WP_Ajax_UnitTestCase {
 		$css      = $controls->get_frontend_css();
 
 		// Assert we get the default values as CSS vars.
-		$this->assertContains( ':root {', $css );
+		$this->assertContains( ':root, body {', $css );
 		$this->assertContains( '--mdc-theme-primary: #6200ee;', $css );
 		$this->assertContains( '--mdc-theme-primary-rgb: 98,0,238;', $css );
 		$this->assertContains( '--mdc-theme-secondary: #018786;', $css );

--- a/theme/assets/src/customizer/customize-preview.js
+++ b/theme/assets/src/customizer/customize-preview.js
@@ -22,7 +22,7 @@
  * @since 1.0.0
  */
 
-/* global jQuery, materialDesignThemeColorControls, materialDesignThemeColorControlsDark */
+/* global jQuery, materialDesignThemeColorControls, materialDesignThemeColorControlsDark, materialDesignThemeColorControlsTheme */
 
 /**
  * External dependencies
@@ -161,6 +161,9 @@ const api = window.wp.customize;
 			}
 
 			styles += `${ cssVar }: ${ color };`;
+			if ( materialDesignThemeColorControlsTheme[ control ] ) {
+				styles += `${ materialDesignThemeColorControlsTheme[ control ] }: ${ color };`;
+			}
 			styles += `${ cssVar }-rgb: ${ hexToRgb( color ).join( ',' ) };`;
 
 			if ( '--mdc-theme-background' === cssVar ) {
@@ -183,6 +186,9 @@ const api = window.wp.customize;
 				}
 
 				darkStyles += `${ cssVar }: ${ color };`;
+				if ( materialDesignThemeColorControlsTheme[ control ] ) {
+					darkStyles += `${ materialDesignThemeColorControlsTheme[ control ] }: ${ color };`;
+				}
 				darkStyles += `${ cssVar }-rgb: ${ hexToRgb( color ).join(
 					','
 				) };`;
@@ -208,6 +214,9 @@ const api = window.wp.customize;
 			}
 
 			lightStyles += `${ cssVar }: ${ color };`;
+			if ( materialDesignThemeColorControlsTheme[ control ] ) {
+				lightStyles += `${ materialDesignThemeColorControlsTheme[ control ] }: ${ color };`;
+			}
 			lightStyles += `${ cssVar }-rgb: ${ hexToRgb( color ).join(
 				','
 			) };`;

--- a/theme/assets/src/customizer/customize-preview.js
+++ b/theme/assets/src/customizer/customize-preview.js
@@ -231,7 +231,7 @@ const api = window.wp.customize;
 			}
 		} );
 
-		styles = `:root {
+		styles = `body {
 			${ styles }
 
 			body[data-color-scheme="dark"] {

--- a/theme/inc/customizer.php
+++ b/theme/inc/customizer.php
@@ -131,14 +131,17 @@ function preview_scripts() {
 	);
 
 	$css_vars      = [];
+	$theme_vars    = [];
 	$css_vars_dark = [];
 
 	foreach ( Colors\get_controls() as $control ) {
-		$css_vars[ $control['id'] ] = $control['css_var'];
+		$css_vars[ $control['id'] ]   = $control['css_var'];
+		$theme_vars[ $control['id'] ] = sprintf( '--wp--preset--color--%s', $control['theme_json'] );
 	}
 
 	foreach ( Colors\get_dark_controls() as $control ) {
 		$css_vars_dark[ $control['id'] ] = $control['css_var'];
+		$theme_vars[ $control['id'] ]    = sprintf( '--wp--preset--color--%s', $control['theme_json'] );
 	}
 
 	wp_localize_script(
@@ -151,6 +154,12 @@ function preview_scripts() {
 		'material-design-google-customizer-preview',
 		'materialDesignThemeColorControlsDark',
 		$css_vars_dark
+	);
+
+	wp_localize_script(
+		'material-design-google-customizer-preview',
+		'materialDesignThemeColorControlsTheme',
+		$theme_vars
 	);
 }
 

--- a/theme/inc/customizer.php
+++ b/theme/inc/customizer.php
@@ -43,7 +43,7 @@ function setup() {
 
 	add_action( 'customize_controls_enqueue_scripts', __NAMESPACE__ . '\scripts' );
 
-	add_action( 'admin_head', __NAMESPACE__ . '\print_css_vars', 2 );
+	add_action( 'admin_head', __NAMESPACE__ . '\print_css_vars', 5 );
 }
 
 /**
@@ -513,7 +513,6 @@ function add_color_controls( $wp_customize, $color_controls, $section ) {
  * Get custom frontend CSS vars based on the customizer theme settings.
  */
 function get_css_vars() {
-	$css             = '';
 	$color_vars      = [];
 	$color_vars_dark = [];
 	$defaults        = get_default_values();
@@ -571,7 +570,7 @@ function get_css_vars() {
 	$color_vars_dark = implode( $glue, $color_vars_dark );
 
 	$css = "
-		:root {
+		:root, body {
 			{$color_vars}
 		}
 
@@ -589,7 +588,7 @@ function get_css_vars() {
 	if ( material_is_plugin_active() && get_dark_mode_status() !== 'inactive' ) {
 		$css .= "
 			@media (prefers-color-scheme: dark) {
-				:root {
+				:root, body {
 					{$color_vars_dark}
 				}
 			}

--- a/theme/inc/customizer/colors.php
+++ b/theme/inc/customizer/colors.php
@@ -38,7 +38,6 @@ const SECTION = 'colors';
 function setup() {
 	add_action( 'customize_register', __NAMESPACE__ . '\register' );
 	add_action( 'customize_save_after', __NAMESPACE__ . '\after_save' );
-	// TODO selective refresh for live preview in customizer with preset variable.
 }
 
 /**
@@ -240,6 +239,7 @@ function get_dark_controls() {
 			'a11y_label'           => __( 'Background', 'material-design-google' ),
 			'related_text_setting' => 'on_background_color_dark',
 			'color_mode_type'      => 'dark',
+			'theme_json'           => 'background',
 		],
 		[
 			'id'              => 'on_background_color_dark',
@@ -248,6 +248,7 @@ function get_dark_controls() {
 			'a11y_label'      => __( 'On Background', 'material-design-google' ),
 			'related_setting' => 'custom_background_color_dark',
 			'color_mode_type' => 'dark',
+			'theme_json'      => 'on_background',
 		],
 		[
 			'id'                   => 'header_color_dark',
@@ -256,6 +257,7 @@ function get_dark_controls() {
 			'a11y_label'           => __( 'On Top app bar', 'material-design-google' ),
 			'related_text_setting' => 'on_header_color_dark',
 			'color_mode_type'      => 'dark',
+			'theme_json'           => 'on-top-app-bar',
 		],
 		[
 			'id'              => 'on_header_color_dark',
@@ -264,6 +266,7 @@ function get_dark_controls() {
 			'a11y_label'      => __( 'Top app bar', 'material-design-google' ),
 			'related_setting' => 'header_color_dark',
 			'color_mode_type' => 'dark',
+			'theme_json'      => 'top-app-bar',
 		],
 		[
 			'id'                   => 'footer_color_dark',
@@ -272,6 +275,7 @@ function get_dark_controls() {
 			'a11y_label'           => __( 'On Footer', 'material-design-google' ),
 			'related_text_setting' => 'on_footer_color_dark',
 			'color_mode_type'      => 'dark',
+			'theme_json'           => 'on-footer',
 		],
 		[
 			'id'              => 'on_footer_color_dark',
@@ -280,6 +284,7 @@ function get_dark_controls() {
 			'a11y_label'      => __( 'Footer', 'material-design-google' ),
 			'related_setting' => 'footer_color_dark',
 			'color_mode_type' => 'dark',
+			'theme_json'      => 'on-footer',
 		],
 	];
 

--- a/theme/inc/customizer/colors.php
+++ b/theme/inc/customizer/colors.php
@@ -26,6 +26,9 @@
 namespace MaterialDesign\Theme\Customizer\Colors;
 
 use MaterialDesign\Theme\Customizer;
+use function MaterialDesign\Theme\BlockEditor\is_fse;
+
+const SECTION = 'colors';
 
 /**
  * Attach hooks.
@@ -34,6 +37,8 @@ use MaterialDesign\Theme\Customizer;
  */
 function setup() {
 	add_action( 'customize_register', __NAMESPACE__ . '\register' );
+	add_action( 'customize_save_after', __NAMESPACE__ . '\after_save' );
+	// TODO selective refresh for live preview in customizer with preset variable.
 }
 
 /**
@@ -87,10 +92,10 @@ function add_settings( $wp_customize ) {
 				get_controls(),
 				get_dark_controls()
 			),
-			'colors'
+			SECTION
 		);
 	} else {
-		Customizer\add_color_controls( $wp_customize, get_controls(), 'colors' );
+		Customizer\add_color_controls( $wp_customize, get_controls(), SECTION );
 	}
 }
 
@@ -102,8 +107,6 @@ function add_settings( $wp_customize ) {
 function get_controls() {
 	$controls = [];
 
-
-
 	if ( ! material_is_plugin_active() ) {
 		$controls = [
 			[
@@ -111,6 +114,8 @@ function get_controls() {
 				'label'      => esc_html__( 'Primary Color', 'material-design-google' ),
 				'css_var'    => '--mdc-theme-primary',
 				'a11y_label' => __( 'Primary', 'material-design-google' ),
+				'theme_json' => 'primary',
+				'order'      => 1,
 			],
 			[
 				'id'         => 'secondary_color',
@@ -118,30 +123,40 @@ function get_controls() {
 				'css_var'    => '--mdc-theme-secondary',
 				'a11y_label' => __( 'Secondary', 'material-design-google' ),
 				'default'    => '#018786',
+				'theme_json' => 'secondary',
+				'order'      => 3,
 			],
 			[
 				'id'         => 'on_primary_color',
 				'label'      => esc_html__( 'On Primary Color (text and icons)', 'material-design-google' ),
 				'css_var'    => '--mdc-theme-on-primary',
 				'a11y_label' => __( 'On Primary', 'material-design-google' ),
+				'theme_json' => 'on-primary',
+				'order'      => 2,
 			],
 			[
 				'id'         => 'on_secondary_color',
 				'label'      => esc_html__( 'On Secondary Color (text and icons)', 'material-design-google' ),
 				'css_var'    => '--mdc-theme-on-secondary',
 				'a11y_label' => __( 'On Secondary', 'material-design-google' ),
+				'theme_json' => 'on_secondary',
+				'order'      => 4,
 			],
 			[
 				'id'         => 'surface_color',
 				'label'      => esc_html__( 'Surface Color', 'material-design-google' ),
 				'css_var'    => '--mdc-theme-surface',
 				'a11y_label' => __( 'Surface', 'material-design-google' ),
+				'theme_json' => 'surface',
+				'order'      => 5,
 			],
 			[
 				'id'         => 'on_surface_color',
 				'label'      => esc_html__( 'On Surface Color (text and icons)', 'material-design-google' ),
 				'css_var'    => '--mdc-theme-on-surface',
 				'a11y_label' => __( 'On Surface', 'material-design-google' ),
+				'theme_json' => 'on_surface',
+				'order'      => 6,
 			],
 		];
 	}
@@ -157,7 +172,8 @@ function get_controls() {
 				'css_var'              => '--mdc-theme-background',
 				'a11y_label'           => __( 'Background', 'material-design-google' ),
 				'related_text_setting' => 'on_background_color',
-
+				'theme_json'           => 'background',
+				'order'                => 7,
 			],
 			[
 				'id'              => 'on_background_color',
@@ -165,6 +181,8 @@ function get_controls() {
 				'css_var'         => '--mdc-theme-on-background',
 				'a11y_label'      => __( 'On Background', 'material-design-google' ),
 				'related_setting' => 'custom_background_color',
+				'theme_json'      => 'on_background',
+				'order'           => 8,
 			],
 			[
 				'id'                   => 'header_color',
@@ -172,6 +190,8 @@ function get_controls() {
 				'css_var'              => '--mdc-theme-header',
 				'a11y_label'           => __( 'On Top app bar', 'material-design-google' ),
 				'related_text_setting' => 'on_header_color',
+				'theme_json'           => 'on-top-app-bar',
+				'order'                => 9,
 			],
 			[
 				'id'              => 'on_header_color',
@@ -179,6 +199,8 @@ function get_controls() {
 				'css_var'         => '--mdc-theme-on-header',
 				'a11y_label'      => __( 'Top app bar', 'material-design-google' ),
 				'related_setting' => 'header_color',
+				'theme_json'      => 'top-app-bar',
+				'order'           => 10,
 			],
 			[
 				'id'                   => 'footer_color',
@@ -186,6 +208,8 @@ function get_controls() {
 				'css_var'              => '--mdc-theme-footer',
 				'a11y_label'           => __( 'On Footer', 'material-design-google' ),
 				'related_text_setting' => 'on_footer_color',
+				'theme_json'           => 'footer',
+				'order'                => 11,
 			],
 			[
 				'id'              => 'on_footer_color',
@@ -193,6 +217,8 @@ function get_controls() {
 				'css_var'         => '--mdc-theme-on-footer',
 				'a11y_label'      => __( 'Footer', 'material-design-google' ),
 				'related_setting' => 'footer_color',
+				'theme_json'      => 'on-footer',
+				'order'           => 12,
 			],
 		]
 	);
@@ -204,8 +230,6 @@ function get_controls() {
  * @return array
  */
 function get_dark_controls() {
-	$controls = [];
-
 	$controls = [
 		[
 			// Using the `custom_` prefix to prevent conflicts with the default WordPress
@@ -260,4 +284,214 @@ function get_dark_controls() {
 	];
 
 	return $controls;
+}
+
+/**
+ * Handle updating theme.json color palette.
+ *
+ * @param \WP_Customize $wp_customize WP_Customize instance.
+ */
+function after_save( $wp_customize ) {
+	if ( ! is_fse() ) {
+		return;
+	}
+	$user_color_palette = get_user_color_palette( $wp_customize );
+
+	// Get the user's theme.json from the CPT.
+	$user_custom_post_type_id     = \WP_Theme_JSON_Resolver::get_user_custom_post_type_id();
+	$user_theme_json_post         = get_post( $user_custom_post_type_id );
+	$user_theme_json_post_content = json_decode( $user_theme_json_post->post_content );
+
+	// Set meta settings.
+	$user_theme_json_post_content->version                     = 2;
+	$user_theme_json_post_content->isGlobalStylesUserThemeJSON = true; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+	// Only reset the palette if the setting exists, otherwise the whole settings array gets destroyed.
+	if ( property_exists( $user_theme_json_post_content, 'settings' ) && property_exists( $user_theme_json_post_content->settings, 'color' ) && property_exists( $user_theme_json_post_content->settings->color, 'palette' ) ) {
+		// Start with reset palette settings.
+		unset( $user_theme_json_post_content->settings->color->palette );
+	}
+
+	// Set the color palette if it is !== the default.
+	if ( ! check_if_colors_are_default( $user_color_palette ) ) {
+		$user_theme_json_post_content = set_settings_array(
+			$user_theme_json_post_content,
+			[ 'settings', 'color', 'palette' ],
+			$user_color_palette
+		);
+	}
+
+	// Update the theme.json with the new settings.
+	$user_theme_json_post->post_content = wp_json_encode( $user_theme_json_post_content );
+	wp_update_post( $user_theme_json_post );
+	clear_wp_global_user_style_cache();
+	delete_transient( 'global_styles' );
+	delete_transient( 'gutenberg_global_styles' );
+	delete_transient( 'gutenberg_global_styles_' . get_stylesheet() );
+}
+
+/**
+ * Clear cache for global style.
+ *
+ * @see \WP_Theme_JSON_Resolver::get_user_data_from_custom_post_type()
+ */
+function clear_wp_global_user_style_cache() {
+	$args      = [
+		'numberposts' => 1,
+		'orderby'     => 'date',
+		'order'       => 'desc',
+		'post_type'   => 'wp_global_styles',
+		'post_status' => [ 'publish' ],
+		'tax_query'   => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+			[
+				'taxonomy' => 'wp_theme',
+				'field'    => 'name',
+				'terms'    => wp_get_theme()->get_stylesheet(),
+			],
+		],
+	];
+	$cache_key = sprintf( 'wp_global_styles_%s', md5( serialize( $args ) ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+	wp_cache_delete( $cache_key );
+}
+
+/**
+ * Get all color controls merged with theme and plugin.
+ *
+ * @return array|void
+ */
+function get_all_color_controls() {
+	$additional_controls = apply_filters( 'material_design_theme_colors_additional_controls', [] );
+
+	$merge_controls = array_merge( get_controls(), $additional_controls );
+	$orders         = array_column( $merge_controls, 'order' );
+
+	array_multisort( $orders, SORT_ASC, $merge_controls );
+
+	return $merge_controls;
+}
+
+/**
+ * Get user color palette.
+ *
+ * @param \WP_Customize $wp_customize WP_Customize instance.
+ *
+ * @return array
+ */
+function get_user_color_palette( $wp_customize ) {
+	$pallets            = build_user_color_palette();
+	$user_color_palette = [];
+	$controls           = get_all_color_controls();
+
+	foreach ( $controls as $control ) {
+		$key = array_search( $control['theme_json'], array_column( $pallets, 'slug' ) );
+		if ( false === $key ) {
+			continue;
+		}
+		$setting = $wp_customize->get_setting( isset( $control['slug'] ) ? $control['slug'] : $control['id'] );
+		$value   = $pallets[ $key ];
+		if ( $setting && null !== $setting->post_value() ) {
+			$value['color'] = $setting->post_value();
+		}
+		// Todo: Maybe handle order.
+		$user_color_palette[] = $value;
+	}
+	return $user_color_palette;
+}
+
+/**
+ * Build the user color palette.
+ *
+ * @return array|mixed
+ */
+function build_user_color_palette() {
+	// Get the merged theme.json.
+	$theme_json = \WP_Theme_JSON_Resolver::get_merged_data()->get_raw_data();
+
+	$combined_color_palette = $theme_json['settings']['color']['palette']['theme'];
+	$user_color_palette     = null;
+	if ( isset( $theme_json['settings']['color']['palette']['custom'] ) ) {
+		$user_color_palette = $theme_json['settings']['color']['palette']['custom'];
+	} elseif ( isset( $theme_json['settings']['color']['palette']['user'] ) ) {
+		// NOTE: This should be removed once Gutenberg 12.1 lands stably in all environments.
+		$user_color_palette = $theme_json['settings']['color']['palette']['user'];
+		// End Gutenberg < 12.1 compatibility patch.
+	}
+
+	// Combine theme settings with user settings.
+	foreach ( $combined_color_palette as $key => $palette_item ) {
+		// make theme color value the default.
+		$combined_color_palette[ $key ]['default'] = $palette_item['color'];
+		// use user color value if there is one.
+		$user_color_value = get_user_color_value( $palette_item['slug'], $user_color_palette );
+		if ( isset( $user_color_value ) ) {
+			$combined_color_palette[ $key ]['color'] = $user_color_value;
+		}
+	}
+
+	return $combined_color_palette;
+}
+
+/**
+ * Get the user color value.
+ *
+ * @param string $slug    Slug.
+ * @param array  $palette Color array.
+ *
+ * @return mixed|null
+ */
+function get_user_color_value( $slug, $palette ) {
+	if ( ! isset( $palette ) ) {
+		return null;
+	}
+	foreach ( $palette as $palette_item ) {
+		if ( $palette_item['slug'] === $slug ) {
+			return $palette_item['color'];
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Check if color are default or added newly.
+ *
+ * @param array $user_color_palette User color palette.
+ *
+ * @return bool
+ */
+function check_if_colors_are_default( $user_color_palette ) {
+	foreach ( $user_color_palette as $palette_color ) {
+		if ( strtoupper( $palette_color['color'] ) !== strtoupper( $palette_color['default'] ) ) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * Assign a value to an object at the given location.
+ * Create the nested objects if they aren't already available.
+ *
+ * @param object $target The object to assign the value to.
+ * @param array  $array  The array describing the location of the property to update.
+ * @param object $value  The value to assign.
+ *
+ * @return  object          The modified $target object with $value assigned where $array describes
+ */
+function set_settings_array( $target, $array, $value ) {
+	$key     = array_shift( $array );
+	$current =& $target;
+	while ( 0 < count( $array ) ) { // phpcs:ignore Squiz.PHP.DisallowSizeFunctionsInLoops.Found
+		if ( ! property_exists( $current, $key ) ) {
+			$current->{$key} = (object) [];
+		}
+		$current =& $current->{ $key };
+
+		// Cast to an object in the case where it's been set as an array.
+		$current = (object) $current;
+
+		$key = array_shift( $array );
+	}
+	$current->{ $key } = $value;
+	return $target;
 }

--- a/theme/inc/customizer/colors.php
+++ b/theme/inc/customizer/colors.php
@@ -485,12 +485,12 @@ function check_if_colors_are_default( $user_color_palette ) {
  */
 function set_settings_array( $target, $array, $value ) {
 	$key     = array_shift( $array );
-	$current =& $target;
+	$current = & $target;
 	while ( 0 < count( $array ) ) { // phpcs:ignore Squiz.PHP.DisallowSizeFunctionsInLoops.Found
 		if ( ! property_exists( $current, $key ) ) {
 			$current->{$key} = (object) [];
 		}
-		$current =& $current->{ $key };
+		$current = & $current->{ $key };
 
 		// Cast to an object in the case where it's been set as an array.
 		$current = (object) $current;

--- a/theme/theme.json
+++ b/theme/theme.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://json.schemastore.org/theme-v1.json",
-  "version": 1,
+  "$schema": "https://schemas.wp.org/trunk/theme.json",
+  "version": 2,
   "customTemplates": [
     {
       "name": "blank",
@@ -22,5 +22,87 @@
       "title": "Footer",
       "area": "footer"
     }
-  ]
+  ],
+  "settings": {
+    "color": {
+      "palette": [
+        {
+          "slug": "primary",
+          "color": "#6200ee",
+          "name": "Primary"
+        },
+        {
+          "slug": "secondary",
+          "color": "#018786",
+          "name": "Secondary"
+        },
+        {
+          "slug": "on-primary",
+          "color": "#ffffff",
+          "name": "On Primary"
+        },
+        {
+          "slug": "on-secondary",
+          "color": "#000000",
+          "name": "On Secondary"
+        },
+        {
+          "slug": "surface",
+          "color": "#ffffff",
+          "name": "Surface"
+        },
+        {
+          "slug": "on-surface",
+          "color": "#000000",
+          "name": "On Surface"
+        },
+        {
+          "slug": "background",
+          "color": "#ffffff",
+          "name": "Background"
+        },
+        {
+          "slug": "on-background",
+          "color": "#000000",
+          "name": "On Background"
+        },
+        {
+          "slug": "top-app-bar",
+          "color": "#F0F0F0",
+          "name": "Top App Bar"
+        },
+        {
+          "slug": "on-top-app-bar",
+          "color": "#F0F0F0",
+          "name": "On Top App Bar"
+        },
+        {
+          "slug": "footer",
+          "color": "#ffffff",
+          "name": "Footer"
+        },
+        {
+          "slug": "on-footer",
+          "color": "#000000",
+          "name": "On Footer"
+        }
+      ]
+    },
+    "custom": {
+      "color": {
+        "primary": "var(--wp--preset--color--primary)",
+        "secondary": "var(--wp--preset--color--secondary)",
+        "on-primary": "var(--wp--preset--color--on-primary)",
+        "on-secondary": "var(--wp--preset--color--on-secondary)",
+        "surface": "var(--wp--preset--color--surface)",
+        "on-surface": "var(--wp--preset--color--on-surface)",
+        "background": "var(--wp--preset--color--background)",
+        "on-background": "var(--wp--preset--color--on-background)",
+        "top-app-bar": "var(--wp--preset--color--top-app-bar)",
+        "on-top-app-bar": "var(--wp--preset--color--on-top-app-bar)",
+        "footer": "var(--wp--preset--color--footer)",
+        "on-footer": "var(--wp--preset--color--on-footer)"
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Map color with Material colors in customizer.
- Auto refresh material color on change in customizer color.
<!-- Please reference the issue this PR addresses. -->
Fixes #

Demo:
https://user-images.githubusercontent.com/5015489/146341259-fb9ae3b9-7951-4753-aae1-db1b8de0e9bb.mp4


## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/material-components/material-design-for-wordpress/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing.md) (updates are often made to the guidelines, check it out periodically).
