### PR TITLE
Add card block

### DIFF
--- a/theme/assets/css/src/base/masonry-grid.css
+++ b/theme/assets/css/src/base/masonry-grid.css
@@ -15,7 +15,7 @@
  */
 
 .masonry-grid-theme,
-ul.wp-block-post-template.is-flex-container {
+.is-style-material-masonry.wp-block-post-template.is-flex-container {
 	grid-gap: var(--mdc-layout-grid-margin-desktop, 24px);
 	grid-template-columns: repeat(auto-fill, minmax(40%, 1fr));
 	grid-auto-rows: var(--mdc-layout-grid-margin-desktop, 24px);
@@ -58,8 +58,8 @@ ul.wp-block-post-template.is-flex-container {
 	}
 }
 
-.wp-block-post-template.is-flex-container.is-flex-container > li,
-.wp-block-query-loop.is-flex-container.is-flex-container > li {
+.is-style-material-masonry.wp-block-post-template.is-flex-container > li,
+.is-style-material-masonry.wp-block-query-loop.is-flex-container > li {
 	width: 100% !important;
 }
 

--- a/theme/assets/css/src/base/masonry-grid.css
+++ b/theme/assets/css/src/base/masonry-grid.css
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-.masonry-grid-theme {
+.masonry-grid-theme,
+ul.wp-block-post-template.is-flex-container {
 	grid-gap: var(--mdc-layout-grid-margin-desktop, 24px);
 	grid-template-columns: repeat(auto-fill, minmax(40%, 1fr));
 	grid-auto-rows: var(--mdc-layout-grid-margin-desktop, 24px);
@@ -28,6 +29,23 @@
 	@nest .material-archive__wide & {
 		grid-template-columns: repeat(auto-fill, minmax(30%, 1fr));
 	}
+
+	&.columns-3 {
+		grid-template-columns: repeat(auto-fill, minmax(30%, 1fr));
+	}
+
+	&.columns-4 {
+		grid-template-columns: repeat(auto-fill, minmax(20%, 1fr));
+	}
+
+	&.columns-5 {
+		grid-template-columns: repeat(auto-fill, minmax(16%, 1fr));
+	}
+
+	&.columns-6 {
+		grid-template-columns: repeat(auto-fill, minmax(14%, 1fr));
+	}
+
 }
 
 .layout-masonry-4 {
@@ -38,6 +56,11 @@
 			width: 25%;
 		}
 	}
+}
+
+.wp-block-post-template.is-flex-container.is-flex-container > li,
+.wp-block-query-loop.is-flex-container.is-flex-container > li {
+	width: 100% !important;
 }
 
 .post-card {

--- a/theme/assets/css/src/editor.css
+++ b/theme/assets/css/src/editor.css
@@ -16,11 +16,11 @@
 
 @import "./conf/variables.css";
 @import "./base/typography.css";
+
 /* Following imports are used for card block. */
 @import "./components/post-card.css";
 @import "./components/avatar.css";
 @import "@material/button/dist/mdc.button.css";
-
 @mixin selector-typography .wp-block div, body1;
 @mixin selector-typography p, body1;
 @mixin selector-typography .editor-post-title__input, headline2, 6, 6, 300;

--- a/theme/assets/css/src/editor.css
+++ b/theme/assets/css/src/editor.css
@@ -16,6 +16,11 @@
 
 @import "./conf/variables.css";
 @import "./base/typography.css";
+/* Following imports are used for card block. */
+@import "./components/post-card.css";
+@import "./components/avatar.css";
+@import "@material/button/dist/mdc.button.css";
+
 @mixin selector-typography .wp-block div, body1;
 @mixin selector-typography p, body1;
 @mixin selector-typography .editor-post-title__input, headline2, 6, 6, 300;

--- a/theme/assets/src/block-editor/blocks/card/block.json
+++ b/theme/assets/src/block-editor/blocks/card/block.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "name": "material/card-query",
+  "category": "material",
+  "attributes": {
+    "showExcerpt": {
+      "type": "boolean",
+      "default": true
+    },
+    "showDate": {
+      "type": "boolean",
+      "default": true
+    },
+    "showAuthor": {
+      "type": "boolean",
+      "default": true
+    },
+    "showComments": {
+      "type": "boolean",
+      "default": true
+    }
+  },
+  "title": "Material Card for Query loop",
+  "supports": {},
+  "apiVersion": 2,
+  "description": "Material card for query loop block",
+  "editorStyle": ["material-google-fonts-cdn", "material-block-editor-css-theme"],
+  "editorScript": "material-block-editor-js-theme",
+  "usesContext": [ "postId", "postType", "queryId" ]
+}

--- a/theme/assets/src/block-editor/blocks/card/block.json
+++ b/theme/assets/src/block-editor/blocks/card/block.json
@@ -18,6 +18,10 @@
     "showComments": {
       "type": "boolean",
       "default": true
+    },
+    "isEditMode": {
+      "type": "boolean",
+      "default": false
     }
   },
   "title": "Material Card for Query loop",

--- a/theme/assets/src/block-editor/blocks/card/block.json
+++ b/theme/assets/src/block-editor/blocks/card/block.json
@@ -26,5 +26,6 @@
   "description": "Material card for query loop block",
   "editorStyle": ["material-google-fonts-cdn", "material-block-editor-css-theme"],
   "editorScript": "material-block-editor-js-theme",
-  "usesContext": [ "postId", "postType", "queryId" ]
+  "usesContext": [ "postId", "postType", "queryId" ],
+  "textdomain": "material-design-google"
 }

--- a/theme/assets/src/block-editor/blocks/card/edit.js
+++ b/theme/assets/src/block-editor/blocks/card/edit.js
@@ -46,6 +46,10 @@ const Edit = ( { context, setAttributes, attributes } ) => {
 	for ( const key in context ) {
 		urlQueryArgs.materialParamContext[ key ] = context[ key ];
 	}
+	const ssrAttributes = {
+		...attributes,
+		...{ isEditMode: true },
+	};
 	return (
 		<>
 			<InspectControls
@@ -56,7 +60,7 @@ const Edit = ( { context, setAttributes, attributes } ) => {
 				<ServerSideRender
 					block={ name }
 					urlQueryArgs={ urlQueryArgs }
-					attributes={ attributes }
+					attributes={ ssrAttributes }
 				/>
 			</div>
 		</>

--- a/theme/assets/src/block-editor/blocks/card/edit.js
+++ b/theme/assets/src/block-editor/blocks/card/edit.js
@@ -56,6 +56,7 @@ const Edit = ( { context, setAttributes, attributes } ) => {
 				<ServerSideRender
 					block={ name }
 					urlQueryArgs={ urlQueryArgs }
+					attributes={ attributes }
 				/>
 			</div>
 		</>

--- a/theme/assets/src/block-editor/blocks/card/edit.js
+++ b/theme/assets/src/block-editor/blocks/card/edit.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed uder the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import ServerSideRender from '@wordpress/server-side-render';
+
+/**
+ * Internal dependencies
+ */
+import { name } from './block.json';
+import InspectControls from './inspectControl';
+
+/**
+ * Edit.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.context
+ * @param {string}   props.context.postType
+ * @param {number}   props.context.postId
+ * @param {number}   props.context.queryId
+ * @param {Function} props.setAttributes
+ * @param {Object}   props.attributes
+ * @return {JSX.Element} Block edit.
+ */
+const Edit = ( { context, setAttributes, attributes } ) => {
+	const urlQueryArgs = {
+		materialParamContext: [],
+	};
+	// Server side rendering doesn't support passing context yet. This hack adds context as url param to later manually parse in php.
+	for ( const key in context ) {
+		urlQueryArgs.materialParamContext[ key ] = context[ key ];
+	}
+	return (
+		<>
+			<InspectControls
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+			/>
+			<div { ...useBlockProps() }>
+				<ServerSideRender
+					block={ name }
+					urlQueryArgs={ urlQueryArgs }
+				/>
+			</div>
+		</>
+	);
+};
+
+export default Edit;

--- a/theme/assets/src/block-editor/blocks/card/edit.js
+++ b/theme/assets/src/block-editor/blocks/card/edit.js
@@ -32,13 +32,10 @@ import InspectControls from './inspectControl';
 /**
  * Edit.
  *
- * @param {Object}   props
- * @param {Object}   props.context
- * @param {string}   props.context.postType
- * @param {number}   props.context.postId
- * @param {number}   props.context.queryId
- * @param {Function} props.setAttributes
- * @param {Object}   props.attributes
+ * @param {Object}                                         props
+ * @param {{postType:string,postId:number,queryId:number}} props.context
+ * @param {Function}                                       props.setAttributes
+ * @param {Object}                                         props.attributes
  * @return {JSX.Element} Block edit.
  */
 const Edit = ( { context, setAttributes, attributes } ) => {

--- a/theme/assets/src/block-editor/blocks/card/icon.js
+++ b/theme/assets/src/block-editor/blocks/card/icon.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Block Icon component.
+ *
+ * @return {JSX.Element} Function returning the HTML markup for the component.
+ */
+export const icon = () => (
+	<i className="material-icons-outlined">chrome_reader_mode</i>
+);

--- a/theme/assets/src/block-editor/blocks/card/index.js
+++ b/theme/assets/src/block-editor/blocks/card/index.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import { icon } from './icon';
+import edit from './edit';
+
+const { name, title } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	title,
+	description: metadata.description,
+	icon,
+	edit,
+};

--- a/theme/assets/src/block-editor/blocks/card/inspectControl.js
+++ b/theme/assets/src/block-editor/blocks/card/inspectControl.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { InspectorControls } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import genericAttributesSetter from '../../../../../../plugin/assets/src/block-editor/utils/generic-attributes-setter';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * @param {Object}   props
+ * @param {Function} props.setAttributes
+ * @param {Object}   props.attributes
+ * @param {boolean}  props.attributes.showExcerpt
+ * @param {boolean}  props.attributes.showDate
+ * @param {boolean}  props.attributes.showAuthor
+ * @param {boolean}  props.attributes.showComments
+ */
+const InspectControls = ( {
+	setAttributes,
+	attributes: { showExcerpt, showDate, showAuthor, showComments },
+} ) => {
+	const setter = genericAttributesSetter( setAttributes );
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __(
+					'Show / Hide post information',
+					'material-design'
+				) }
+				initialOpen={ true }
+			>
+				<ToggleControl
+					label={ __( 'Post date', 'material-design' ) }
+					checked={ showDate }
+					onChange={ setter( 'showDate' ) }
+				/>
+				<ToggleControl
+					label={ __( 'Post excerpt', 'material-design' ) }
+					checked={ showExcerpt }
+					onChange={ setter( 'showExcerpt' ) }
+				/>
+				<ToggleControl
+					label={ __( 'Author', 'material-design' ) }
+					checked={ showAuthor }
+					onChange={ setter( 'showAuthor' ) }
+				/>
+				<ToggleControl
+					label={ __( 'Comments', 'material-design' ) }
+					checked={ showComments }
+					onChange={ setter( 'showComments' ) }
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+};
+
+export default InspectControls;

--- a/theme/assets/src/block-editor/blocks/card/save.js
+++ b/theme/assets/src/block-editor/blocks/card/save.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed uder the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import ServerSideRender from '@wordpress/server-side-render';
+
+import { name } from './block.json';
+/**
+ * Edit.
+ *
+ * @return {JSX.Element} Block edit.
+ */
+const Edit = () => {
+	return (
+		<div { ...useBlockProps.save() }>
+			<ServerSideRender block={ name } />
+		</div>
+	);
+};
+
+export default Edit;

--- a/theme/assets/src/block-editor/plugins/style/core-template/index.js
+++ b/theme/assets/src/block-editor/plugins/style/core-template/index.js
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-import './plugins/hide-sections';
-import './plugins/style/core-template';
-import { registerBlocks } from './util';
+import { registerBlockStyle } from '@wordpress/blocks';
 
-/**
- * Register the blocks.
- */
-registerBlocks( require.context( './blocks', true, /(?<!test\/)index\.js$/ ) );
+registerBlockStyle( 'core/post-template', {
+	name: 'material-masonry',
+	label: 'Material Masonry Grid',
+} );

--- a/theme/assets/src/front-end/components/masonry.js
+++ b/theme/assets/src/front-end/components/masonry.js
@@ -40,7 +40,9 @@ const handleResize = mediaQuery => {
 
 const resizeAllGridItems = () => {
 	const cells = materialDesignThemeFeVars?.isFse
-		? gridElement.querySelectorAll( '.wp-block-post' )
+		? gridElement.querySelectorAll(
+				'.is-style-material-masonry .wp-block-post'
+		  )
 		: gridElement.querySelectorAll( '.post-card__container' );
 
 	if ( ! cells ) {

--- a/theme/assets/src/front-end/components/masonry.js
+++ b/theme/assets/src/front-end/components/masonry.js
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+/* global materialDesignThemeFeVars */
 let gridElement = null;
 
 export const masonryInit = () => {
-	gridElement = document.querySelector( '.masonry-grid-theme' );
+	/** @type {{isFse:boolean}} */
+	gridElement = materialDesignThemeFeVars?.isFse
+		? document.querySelector( '.is-flex-container' )
+		: document.querySelector( '.masonry-grid-theme' );
 
 	if ( ! gridElement ) {
 		return;
@@ -36,7 +39,9 @@ const handleResize = mediaQuery => {
 };
 
 const resizeAllGridItems = () => {
-	const cells = gridElement.querySelectorAll( '.post-card__container' );
+	const cells = materialDesignThemeFeVars?.isFse
+		? gridElement.querySelectorAll( '.wp-block-post' )
+		: gridElement.querySelectorAll( '.post-card__container' );
 
 	if ( ! cells ) {
 		return;

--- a/theme/block-templates/search.html
+++ b/theme/block-templates/search.html
@@ -1,18 +1,11 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:group {"layout":{"inherit":true}, "tagName":"main"} -->
-<main class="wp-block-group">
-
-	<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
-	<!-- wp:post-template -->
-
-		<!-- wp:post-title {"level":5,"isLink":true} /-->
-		<!-- wp:post-excerpt /-->
-
-	<!-- /wp:post-template -->
-	<!-- /wp:query -->
-
-</main>
+<!-- wp:group {"layout":{"wideSize":"100vw","contentSize":"840px"}} -->
+<div class="wp-block-group"><!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":2}} -->
+	<div class="wp-block-query"><!-- wp:post-template -->
+		<!-- wp:material/card-query /-->
+		<!-- /wp:post-template --></div>
+	<!-- /wp:query --></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->

--- a/theme/functions.php
+++ b/theme/functions.php
@@ -182,9 +182,13 @@ function material_design_theme_scripts() {
 	}
 
 	wp_enqueue_script( 'material-design-google-js', get_template_directory_uri() . "/assets/js/front-end{$suffix}.js", [], $theme_version, true );
-	wp_localize_script( 'material-design-google-js', 'materialDesignThemeFeVars', [
-		'isFse' => is_fse(),
-	] );
+	wp_localize_script(
+		'material-design-google-js',
+		'materialDesignThemeFeVars',
+		[
+			'isFse' => is_fse(),
+		]
+	);
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );

--- a/theme/functions.php
+++ b/theme/functions.php
@@ -25,6 +25,8 @@
  * @package MaterialDesign
  */
 
+use function MaterialDesign\Theme\BlockEditor\is_fse;
+
 if ( ! function_exists( 'material_design_theme_setup' ) ) :
 	/**
 	 * Sets up theme defaults and registers support for various WordPress features.
@@ -180,6 +182,9 @@ function material_design_theme_scripts() {
 	}
 
 	wp_enqueue_script( 'material-design-google-js', get_template_directory_uri() . "/assets/js/front-end{$suffix}.js", [], $theme_version, true );
+	wp_localize_script( 'material-design-google-js', 'materialDesignThemeFeVars', [
+		'isFse' => is_fse(),
+	] );
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );

--- a/theme/inc/blocks/class-blocks.php
+++ b/theme/inc/blocks/class-blocks.php
@@ -64,7 +64,8 @@ class Blocks {
 			/**
 			 * Filters the arguments for registering a block type.
 			 *
-			 * @param array $metadata Array of arguments for registering a block type.
+			 * @param array  $metadata Array of arguments for registering a block type.
+			 * @param string $name     Block name.
 			 */
 			$args = apply_filters( 'material_design_theme_block_type_args', $args, $object->name );
 			// If this is a dynamic block, register render_callback.

--- a/theme/template-parts/blocks/card-query.php
+++ b/theme/template-parts/blocks/card-query.php
@@ -78,11 +78,11 @@ $post_link = $is_edit ? '#link-to-' . $post_ID : get_the_permalink( $post );
 								class="post-card__subtitle mdc-typography mdc-typography--subtitle2"><?php echo esc_html( get_the_time( 'F j, Y', $post ) ); ?></time>
 						<?php endif; ?>
 					</div>
-					<?php if ( ! empty( $show_excerpt ) ) : ?>
-						<div
-							class="post-card__secondary mdc-typography mdc-typography--body2"><?php get_the_excerpt( $post ); ?></div>
-					<?php endif; ?>
 				</div>
+				<?php if ( ! empty( $show_excerpt ) ) : ?>
+					<div
+						class="post-card__secondary mdc-typography mdc-typography--body2"><p><?php echo wp_kses_post( get_the_excerpt( $post ) ); ?></p></div>
+				<?php endif; ?>
 			</a>
 			<?php if ( ! empty( $show_author ) || ! empty( $show_comments ) ) : ?>
 				<div class="mdc-card__actions">

--- a/theme/template-parts/blocks/card-query.php
+++ b/theme/template-parts/blocks/card-query.php
@@ -31,17 +31,19 @@ $show_comments = $attributes['showComments'];
 $show_author   = $attributes['showAuthor'];
 $show_excerpt  = $attributes['showExcerpt'];
 $show_date     = $attributes['showDate'];
+$is_edit       = $attributes['isEditMode'];
 $classes       = get_theme_mod( 'archive_outlined', false ) ? 'mdc-card--outlined' : '';
 
 if ( empty( $block ) || ! isset( $block->context['postId'] ) ) {
 	return '';
 }
-$post_ID = $block->context['postId']; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-$post    = get_post( $post_ID ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+$post_ID   = $block->context['postId']; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+$post      = get_post( $post_ID ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+$post_link = $is_edit ? '#link-to-' . $post_ID : get_the_permalink( $post );
 ?>
 	<div class="post-card__container">
 		<div id="<?php echo esc_attr( $post_ID ); ?>" <?php post_class( "mdc-card post-card $classes" ); ?>>
-			<a class="mdc-card__link" href="<?php echo esc_url( get_the_permalink( $post ) ); ?>">
+			<a class="mdc-card__link" href="<?php echo esc_url( $post_link ); ?>">
 				<div class="mdc-card__primary-action post-card__primary-action">
 					<?php if ( has_post_thumbnail( $post ) ) : ?>
 						<div class="mdc-card__media mdc-card__media--16-9 post-card__media">
@@ -88,7 +90,7 @@ $post    = get_post( $post_ID ); // phpcs:ignore WordPress.WP.GlobalVariablesOve
 						<?php if ( ! empty( $show_author ) ) : ?>
 							<a
 								class="mdc-button mdc-card__action mdc-card__action--button"
-								href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID', $post->post_author ) ) ); ?>"
+								href="<?php echo esc_url( $is_edit ? '#author-link' : get_author_posts_url( get_the_author_meta( 'ID', $post->post_author ) ) ); ?>"
 								aria-label="
 								<?php
 								printf(
@@ -109,7 +111,7 @@ $post    = get_post( $post_ID ); // phpcs:ignore WordPress.WP.GlobalVariablesOve
 						<?php endif; ?>
 
 						<?php if ( ! empty( $show_comments ) && ( comments_open( $post_ID ) || ( 0 < get_comments_number( $post_ID ) ) ) ) : ?>
-							<a href="<?php echo esc_url( get_comments_link() ); ?>" class="mdc-button mdc-card__action mdc-card__action--button">
+							<a href="<?php echo esc_url( $is_edit ? '#comment-link' : get_comments_link( $post_ID ) ); ?>" class="mdc-button mdc-card__action mdc-card__action--button">
 								<span class="mdc-button__ripple"></span>
 								<i class="material-icons mdc-button__icon" aria-hidden="true">comment</i>
 								<?php

--- a/theme/template-parts/blocks/card-query.php
+++ b/theme/template-parts/blocks/card-query.php
@@ -104,7 +104,7 @@ $post    = get_post( $post_ID ); // phpcs:ignore WordPress.WP.GlobalVariablesOve
 							>
 								<span class="mdc-button__ripple"></span>
 								<?php echo get_avatar( get_the_author_meta( 'ID', $post->post_author ), 18 ); ?>
-								<?php the_author(); ?>
+								<?php echo esc_html( apply_filters( 'the_author', get_the_author_meta( 'display_name', $post->post_author ) ) ); ?>
 							</a>
 						<?php endif; ?>
 

--- a/theme/template-parts/blocks/card-query.php
+++ b/theme/template-parts/blocks/card-query.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @package MaterialDesign
+ */
+
+/**
+ * Template part for displaying posts
+ *
+ * @link    https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package MaterialDesign
+ */
+$block         = isset( $args['block'] ) ? $args['block'] : [];
+$attributes    = isset( $args['attributes'] ) ? $args['attributes'] : [];
+$content       = isset( $args['content'] ) ? $args['content'] : [];
+$show_comments = $attributes['showComments'];
+$show_author   = $attributes['showAuthor'];
+$show_excerpt  = $attributes['showExcerpt'];
+$show_date     = $attributes['showDate'];
+$classes       = get_theme_mod( 'archive_outlined', false ) ? 'mdc-card--outlined' : '';
+
+if ( empty( $block ) || ! isset( $block->context['postId'] ) ) {
+	return '';
+}
+$post_ID = $block->context['postId']; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+$post    = get_post( $post_ID ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+?>
+	<div class="post-card__container">
+		<div id="<?php echo esc_attr( $post_ID ); ?>" <?php post_class( "mdc-card post-card $classes" ); ?>>
+			<a class="mdc-card__link" href="<?php echo esc_url( get_the_permalink( $post ) ); ?>">
+				<div class="mdc-card__primary-action post-card__primary-action">
+					<?php if ( has_post_thumbnail( $post ) ) : ?>
+						<div class="mdc-card__media mdc-card__media--16-9 post-card__media">
+							<?php echo get_the_post_thumbnail( $post ); ?>
+						</div>
+					<?php endif; ?>
+					<div class="post-card__primary">
+						<?php if ( is_sticky( $post_ID ) ) : ?>
+							<h2
+								class="post-card__title mdc-typography mdc-typography--headline6"
+								aria-label="
+							<?php
+								printf(
+								/* translators: Post title */
+									esc_attr__( 'Sticky post: %s', 'material-design-google' ),
+									esc_attr( get_the_title( $post ) )
+								);
+							?>
+							"
+							>
+								<i class="material-icons" aria-hidden="true">push_pin</i>
+								<?php echo esc_html( get_the_title( $post ) ); ?>
+							</h2>
+						<?php else : ?>
+							<h2 class="post-card__title mdc-typography mdc-typography--headline6">
+								<?php echo esc_html( get_the_title( $post ) ); ?>
+							</h2>
+						<?php endif; ?>
+
+						<?php if ( ! empty( $show_date ) ) : ?>
+							<time
+								class="post-card__subtitle mdc-typography mdc-typography--subtitle2"><?php echo esc_html( get_the_time( 'F j, Y', $post ) ); ?></time>
+						<?php endif; ?>
+					</div>
+					<?php if ( ! empty( $show_excerpt ) ) : ?>
+						<div
+							class="post-card__secondary mdc-typography mdc-typography--body2"><?php get_the_excerpt( $post ); ?></div>
+					<?php endif; ?>
+				</div>
+			</a>
+			<?php if ( ! empty( $show_author ) || ! empty( $show_comments ) ) : ?>
+				<div class="mdc-card__actions">
+					<div class="mdc-card__action-buttons">
+						<?php if ( ! empty( $show_author ) ) : ?>
+							<a
+								class="mdc-button mdc-card__action mdc-card__action--button"
+								href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID', $post->post_author ) ) ); ?>"
+								aria-label="
+								<?php
+								printf(
+								/* translators: 1: author name. */
+									esc_attr__(
+										'Author: %s',
+										'material-design-google'
+									),
+									esc_attr( get_the_author_meta( 'display_name', $post->post_author ) )
+								);
+								?>
+							"
+							>
+								<span class="mdc-button__ripple"></span>
+								<?php echo get_avatar( get_the_author_meta( 'ID', $post->post_author ), 18 ); ?>
+								<?php the_author(); ?>
+							</a>
+						<?php endif; ?>
+
+						<?php if ( ! empty( $show_comments ) && ( comments_open( $post_ID ) || ( 0 < get_comments_number( $post_ID ) ) ) ) : ?>
+							<a href="<?php echo esc_url( get_comments_link() ); ?>" class="mdc-button mdc-card__action mdc-card__action--button">
+								<span class="mdc-button__ripple"></span>
+								<i class="material-icons mdc-button__icon" aria-hidden="true">comment</i>
+								<?php
+								echo esc_html(
+									sprintf(
+									/* translators: 1: comment count. */
+										_nx( // phpcs:disable
+											'One Comment', // phpcs:disable
+											'%s Comments',
+											get_comments_number( $post_ID ),
+											'comments title',
+											'material-design-google'
+										),
+										number_format_i18n( get_comments_number( $post_ID ) )
+									)
+								);
+								?>
+							</a>
+						<?php endif; ?>
+					</div>
+				</div>
+			<?php endif; ?>
+		</div>
+	</div>


### PR DESCRIPTION
## Summary

- Insert material query loop card in post template.
- Tweak Date, author, comments, summary.
- Post template has masonary grid. 

<!-- Please reference the issue this PR addresses. -->
Fixes #237 

![image](https://user-images.githubusercontent.com/5015489/150264002-e410bf17-3374-4feb-9149-b3e0092d07b6.png)


## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/material-components/material-design-for-wordpress/issues) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing/engineering.md#tests).
- [x] My code follows the [Contributing Guidelines](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing.md) (updates are often made to the guidelines, check it out periodically).
