### PR TITLE
Whitelist block.json in theme bundle

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,6 +86,7 @@ module.exports = function ( grunt ) {
 					'!theme/assets/js/*.map',
 					'!theme/assets/js/editor*',
 					'!theme/assets/src/**',
+					'theme/assets/src/**/*.json',
 					'!theme/tests/**',
 					'!theme/wp-assets/**',
 					'!theme/composer*',

--- a/theme/assets/src/block-editor/blocks/back-to-top/block.json
+++ b/theme/assets/src/block-editor/blocks/back-to-top/block.json
@@ -11,7 +11,7 @@
   },
   "description": "Material back to top button",
   "editorStyle": [
-    "material-google-fonts-cdn",
+    "material-google-fonts",
     "material-block-editor-css-theme"
   ],
   "editorScript": "material-block-editor-js-theme"

--- a/theme/assets/src/block-editor/blocks/card/block.json
+++ b/theme/assets/src/block-editor/blocks/card/block.json
@@ -28,7 +28,7 @@
   "supports": {},
   "apiVersion": 2,
   "description": "Material card for query loop block",
-  "editorStyle": ["material-google-fonts-cdn", "material-block-editor-css-theme"],
+  "editorStyle": ["material-google-fonts", "material-block-editor-css-theme"],
   "editorScript": "material-block-editor-js-theme",
   "usesContext": [ "postId", "postType", "queryId" ],
   "textdomain": "material-design-google"

--- a/theme/assets/src/block-editor/blocks/dark-mode-switch/block.json
+++ b/theme/assets/src/block-editor/blocks/dark-mode-switch/block.json
@@ -8,7 +8,7 @@
   "title": "Dark Mode Switch",
   "description": "Material dark mode switch",
   "editorStyle": [
-    "material-google-fonts-cdn",
+    "material-google-fonts",
     "material-block-editor-css-theme"
   ],
   "editorScript": "material-block-editor-js-theme"

--- a/theme/assets/src/block-editor/blocks/search/block.json
+++ b/theme/assets/src/block-editor/blocks/search/block.json
@@ -9,7 +9,7 @@
   "supports": {},
   "description": "Material search bar",
   "editorStyle": [
-    "material-google-fonts-cdn",
+    "material-google-fonts",
     "material-block-editor-css-theme"
   ],
   "editorScript": "material-block-editor-js-theme"

--- a/theme/inc/block-editor.php
+++ b/theme/inc/block-editor.php
@@ -83,9 +83,11 @@ function enqueue_block_editor_assets() {
 		$version,
 		false
 	);
-	if ( ! wp_style_is( 'material-google-fonts-cdn', 'enqueued' ) ) {
+
+	if ( ! wp_style_is( 'material-google-fonts', 'enqueued' ) ) {
+		// Ideally this should be injected by the plugin if not fallback to default fonts.
 		wp_enqueue_style(
-			'material-google-fonts-cdn',
+			'material-google-fonts',
 			esc_url( '//fonts.googleapis.com/css?family=Roboto|Material+Icons' ),
 			[],
 			$theme_version


### PR DESCRIPTION
## Summary
Allow block.json to be part of build.
<!-- Please reference the issue this PR addresses. -->
Fixes #

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/material-components/material-design-for-wordpress/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing.md) (updates are often made to the guidelines, check it out periodically).
