### PR TITLE
Pagination use disabled links

### DIFF
--- a/theme/template-parts/blocks/query-pagination-first.php
+++ b/theme/template-parts/blocks/query-pagination-first.php
@@ -30,47 +30,41 @@ $default_label      = __( 'First', 'material-design-google' );
 $label              = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
 $content            = '';
 $url                = '';
-$wrapper_attributes = str_replace( 'class="', 'class="mdc-ripple-surface ', $wrapper_attributes );
 
 // Check if the pagination is for Query that inherits the global context
 // and handle appropriately.
 if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
-	$url = get_pagenum_link( 1 );
-} elseif ( 1 !== $page_number ) {
+	global $wp_query;
+	$url               = get_pagenum_link( 1 );
+	$query_page_number = (int) get_query_var( 'paged' );
+	$page_number       = $query_page_number > 0 ? $query_page_number : $page_number;
+} else {
 	$url = add_query_arg( $page_key, 1 );
 }
+$is_disabled = 1 === $page_number;
 
 if ( ! empty( $url ) ) :
-	ob_start();
+	$screen_reader = sprintf(
+	/* translators: available page description. */
+		esc_html__( '%s page', 'material-design-google' ),
+		esc_html( $label )
+	);
+	$inner_content             = sprintf(
+		'<span class="material-icons" aria-hidden="true">first_page</span>
+	<span class="screen-reader-text">%s</span>',
+		$screen_reader
+	);
+	$inner_content_with_anchor = $is_disabled ? $inner_content : sprintf(
+		'<a href="%s" class="mdc-ripple-surface">%s</a>',
+		esc_url( $url ),
+		$inner_content
+	);
+	$content                   = sprintf(
+		'<li %s>%s</li>',
+		$wrapper_attributes,
+		$inner_content_with_anchor
+	);
 	?>
-	<li>
-		<a
-			href="<?php echo esc_url( $url ); ?>"
-			<?php
-			/**
-			 * Esc_attr breaks the markup.
-			 * Turns the closing " into &quote;
-			 */
-			?>
-			<?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-		>
-			<span class="material-icons" aria-hidden="true">
-				first_page
-			</span>
-			<span class="screen-reader-text">
-				<?php
-					printf(
-						/* translators: available page description. */
-						esc_html__( '%s page', 'material-design-google' ),
-						esc_html( $label )
-					);
-				?>
-			</span>
-		</a>
-	</li>
 	<?php
-
-	$content = ob_get_clean();
-
 	echo wp_kses_post( $content );
 endif;

--- a/theme/template-parts/blocks/query-pagination-last.php
+++ b/theme/template-parts/blocks/query-pagination-last.php
@@ -31,58 +31,49 @@ $default_label      = __( 'Last', 'material-design-google' );
 $label              = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
 $content            = '';
 $url                = '';
-
+$is_disabled        = false;
 // Check if the pagination is for Query that inherits the global context.
 if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
 
 	// Take into account if we have set a bigger `max page`
 	// than what the query has.
 	global $wp_query;
-	$url = get_pagenum_link( $wp_query->max_num_pages );
+	$max_page         = $wp_query->max_num_pages;
+	$url              = get_pagenum_link( $max_page );
+	$current_page_num = get_query_var( 'paged' );
+	$is_disabled      = (int) $current_page_num === (int) $max_page;
 
 } elseif ( ! $max_page || $max_page > $page_number ) {
 	$custom_query           = new WP_Query( build_query_vars_from_query_block( $block, $page_number ) );
 	$custom_query_max_pages = (int) $custom_query->max_num_pages;
-	$wrapper_attributes     = str_replace( 'class="', 'class="mdc-ripple-surface ', $wrapper_attributes );
-
-	if ( $custom_query_max_pages && $custom_query_max_pages !== $page_number ) :
-		$url = add_query_arg( $page_key, $custom_query_max_pages );
-	endif;
+	$is_disabled            = $custom_query_max_pages === $page_number;
+	$url                    = add_query_arg( $page_key, $custom_query_max_pages );
 
 	wp_reset_postdata(); // Restore original Post Data.
 }
 
 if ( ! empty( $url ) ) :
-	ob_start();
+	$screen_reader = sprintf(
+	/* translators: available page description. */
+		esc_html__( '%s page', 'material-design-google' ),
+		esc_html( $label )
+	);
+	$inner_content             = sprintf(
+		'<span class="material-icons" aria-hidden="true">last_page</span>
+	<span class="screen-reader-text">%s</span>',
+		$screen_reader
+	);
+	$inner_content_with_anchor = $is_disabled ? $inner_content : sprintf(
+		'<a href="%s" class="mdc-ripple-surface">%s</a>',
+		esc_url( $url ),
+		$inner_content
+	);
+	$content                   = sprintf(
+		'<li %s>%s</li>',
+		$wrapper_attributes,
+		$inner_content_with_anchor
+	);
 	?>
-	<li>
-		<a
-			href="<?php echo esc_url( $url ); ?>"
-			<?php
-			/**
-			 * Esc_attr breaks the markup.
-			 * Turns the closing " into &quote;
-			 */
-			?>
-			<?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-		>
-			<span class="material-icons" aria-hidden="true">
-				last_page
-			</span>
-			<span class="screen-reader-text">
-				<?php
-					printf(
-						/* translators: available page description. */
-						esc_html__( '%s page', 'material-design-google' ),
-						esc_html( $label )
-					);
-				?>
-			</span>
-		</a>
-	</li>
 	<?php
-
-	$content = ob_get_clean();
-
 	echo wp_kses_post( $content );
 endif;


### PR DESCRIPTION
## Summary
Previously pagination not showing links altogether instead use
disabled state when links are not required for a given page.

Example: On last pagination page, the last page link is disabled instead
of being visible.

Demo:

https://user-images.githubusercontent.com/5015489/152501562-a0a04972-23c2-4ef5-afd8-c8f143dcd3ed.mp4





<!-- Please reference the issue this PR addresses. -->
Fixes #236 

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/material-components/material-design-for-wordpress/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing.md) (updates are often made to the guidelines, check it out periodically).
