### PR TITLE
Fix context for card

### DIFF
--- a/theme/inc/blocks/class-blocks.php
+++ b/theme/inc/blocks/class-blocks.php
@@ -124,7 +124,7 @@ class Blocks {
 		}
 
 		// Remove this once server side context is available via gutenberg.
-		if ( ! empty( $block->block_type->uses_context ) && empty( $block->context ) ) {
+		if ( ! empty( $block->block_type->uses_context ) && ! empty( $_GET['materialParamContext'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			foreach ( $block->block_type->uses_context as $context ) {
 				if ( empty( $_GET['materialParamContext'][ $context ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 					continue;


### PR DESCRIPTION
## Summary
Fixes issue when adding query loop with material card shows posts being editing for all cards.

<details><summary>Before</summary>
<p>

![image](https://user-images.githubusercontent.com/5015489/152507501-c94d6ec6-a9d7-46ad-8c12-78ea46bba67e.png)


</p>
</details>

<details><summary>After</summary>
<p>

![image](https://user-images.githubusercontent.com/5015489/152507590-3fcf6da1-e55d-410d-889d-b4308f6d54ff.png)


</p>
</details>
<!-- Please reference the issue this PR addresses. -->
Fixes #237 

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/material-components/material-design-for-wordpress/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing.md) (updates are often made to the guidelines, check it out periodically).
