### PR TITLE
FSE: Override post navigation next → icon after the post title

### DIFF
--- a/theme/assets/src/block-editor/index.js
+++ b/theme/assets/src/block-editor/index.js
@@ -15,6 +15,7 @@
  */
 
 import './plugins/hide-sections';
+import './plugins/post-navigation-link';
 import './style';
 import { registerBlocks } from './util';
 import './hooks';

--- a/theme/assets/src/block-editor/plugins/post-navigation-link/edit.js
+++ b/theme/assets/src/block-editor/plugins/post-navigation-link/edit.js
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Note this block is copied from the core/post-navigation-link block to provide position for label.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/4b4f328220f357306f83225e1b67b1316656ec18/packages/block-library/src/post-navigation-link/edit.js
+ */
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { ToggleControl, PanelBody } from '@wordpress/components';
+import {
+	InspectorControls,
+	RichText,
+	BlockControls,
+	AlignmentToolbar,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+export default function Edit( {
+	attributes: { type, label, showTitle, textAlign, linkLabel, position },
+	setAttributes,
+} ) {
+	const isNext = type === 'next';
+	let placeholder = isNext ? __( 'Next' ) : __( 'Previous' );
+
+	if ( showTitle ) {
+		/* translators: Label before for next and previous post. There is a space after the colon. */
+		placeholder = isNext ? __( 'Next: ' ) : __( 'Previous: ' );
+	}
+
+	const ariaLabel = isNext ? __( 'Next post' ) : __( 'Previous post' );
+	const blockProps = useBlockProps( {
+		className: classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
+	const isPositionAfter = position === 'after';
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody>
+					<ToggleControl
+						label={ __(
+							'Display the title as a link',
+							'material-design-google'
+						) }
+						help={ __(
+							'If you have entered a custom label, it will be prepended before the title.',
+							'material-design-google'
+						) }
+						checked={ !! showTitle }
+						onChange={ () =>
+							setAttributes( {
+								showTitle: ! showTitle,
+							} )
+						}
+					/>
+					{ showTitle && (
+						<ToggleControl
+							label={ __(
+								'Include the label as part of the link',
+								'material-design-google'
+							) }
+							checked={ !! linkLabel }
+							onChange={ () =>
+								setAttributes( {
+									linkLabel: ! linkLabel,
+								} )
+							}
+						/>
+					) }
+				</PanelBody>
+			</InspectorControls>
+			<BlockControls>
+				<AlignmentToolbar
+					value={ textAlign }
+					onChange={ nextAlign => {
+						setAttributes( { textAlign: nextAlign } );
+					} }
+				/>
+			</BlockControls>
+			<div { ...blockProps }>
+				{ ! isPositionAfter && (
+					<RichText
+						tagName="a"
+						aria-label={ ariaLabel }
+						placeholder={ placeholder }
+						value={ label }
+						allowedFormats={ [ 'core/bold', 'core/italic' ] }
+						onChange={ newLabel =>
+							setAttributes( { label: newLabel } )
+						}
+					/>
+				) }
+				{ showTitle && (
+					<a
+						href="#post-navigation-pseudo-link"
+						onClick={ event => event.preventDefault() }
+					>
+						{ __( 'An example title', 'material-design-google' ) }
+					</a>
+				) }
+				{ isPositionAfter && (
+					<RichText
+						tagName="a"
+						aria-label={ ariaLabel }
+						placeholder={ placeholder }
+						value={ label }
+						allowedFormats={ [ 'core/bold', 'core/italic' ] }
+						onChange={ newLabel =>
+							setAttributes( { label: newLabel } )
+						}
+					/>
+				) }
+			</div>
+		</>
+	);
+}

--- a/theme/assets/src/block-editor/plugins/post-navigation-link/index.js
+++ b/theme/assets/src/block-editor/plugins/post-navigation-link/index.js
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { __ } from '@wordpress/i18n';
+import {
+	PanelBody,
+	PanelRow,
+	Button,
+	ButtonGroup,
+} from '@wordpress/components';
+import { addFilter } from '@wordpress/hooks';
+import { InspectorControls } from '@wordpress/block-editor';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
+import Edit from './edit';
+import genericAttributesSetter from '../../../../../../plugin/assets/src/block-editor/utils/generic-attributes-setter';
+
+const targetBlock = 'core/post-navigation-link';
+
+// Add additional attributes to Cover block.
+const overrideAttributes = ( settings, name ) => {
+	if ( targetBlock === name ) {
+		if ( ! settings.attributes ) {
+			settings.attributes = {};
+		}
+
+		settings.attributes.position = {
+			type: 'string',
+			default: 'before',
+		};
+	}
+
+	return settings;
+};
+
+addFilter(
+	'blocks.registerBlockType',
+	targetBlock + '/attributes',
+	overrideAttributes
+);
+
+// Add inspector controls to Cover block.
+const editElement = createHigherOrderComponent(
+	BlockEdit => props => {
+		if ( props.name !== targetBlock ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		const { attributes, setAttributes } = props;
+
+		const onChangePosition = genericAttributesSetter( setAttributes )(
+			'position'
+		);
+		return (
+			<>
+				<Edit { ...props } />
+				<InspectorControls>
+					<PanelBody
+						title={ __(
+							'Label position',
+							'material-design-google'
+						) }
+						initialOpen
+					>
+						<PanelRow>
+							<ButtonGroup>
+								<Button
+									variant={
+										attributes.position === 'before'
+											? 'primary'
+											: undefined
+									}
+									icon={ chevronLeft }
+									onClick={ () => {
+										console.log( 'before' );
+										onChangePosition( 'before' );
+									} }
+									label={ __(
+										'Before',
+										'material-design-google'
+									) }
+								>
+									{ __( 'Before', 'material-design-google' ) }
+								</Button>
+								<Button
+									variant={
+										attributes.position === 'after'
+											? 'primary'
+											: undefined
+									}
+									icon={ chevronRight }
+									onClick={ () => {
+										console.log( 'after' );
+										onChangePosition( 'after' );
+									} }
+									label={ __(
+										'After',
+										'material-design-google'
+									) }
+								>
+									{ __( 'After', 'material-design-google' ) }
+								</Button>
+							</ButtonGroup>
+						</PanelRow>
+					</PanelBody>
+				</InspectorControls>
+			</>
+		);
+	},
+	'withInspectorControl'
+);
+
+addFilter( 'editor.BlockEdit', targetBlock + '/settings', editElement );

--- a/theme/block-templates/single.html
+++ b/theme/block-templates/single.html
@@ -39,7 +39,7 @@
 		<!-- /wp:column -->
 
 		<!-- wp:column -->
-		<div class="wp-block-column"><!-- wp:post-navigation-link {"textAlign":"right","label":"→","showTitle":true,"linkLabel":true} /--></div>
+		<div class="wp-block-column"><!-- wp:post-navigation-link {"textAlign":"right","label":"→","showTitle":true,"linkLabel":true,"position":"after"} /--></div>
 		<!-- /wp:column --></div>
 	<!-- /wp:columns --></footer>
 <!-- /wp:group -->

--- a/theme/inc/blocks/class-override.php
+++ b/theme/inc/blocks/class-override.php
@@ -68,6 +68,12 @@ class Override {
 			return $settings;
 		}
 
+		// Add additional attribute for position.
+		$settings['attributes']['position'] = [
+			'type'    => 'string',
+			'default' => 'before',
+		];
+
 		$settings['render_callback'] = [ $this, 'render_post_navigation_links' ];
 
 		return $settings;
@@ -113,6 +119,8 @@ class Override {
 			$link  = $label;
 		}
 
+		$position = isset( $attributes['position'] ) ? $attributes['position'] : 'before';
+
 		// If we want to also show the page title, make the page title a link and prepend the label.
 		if ( isset( $attributes['showTitle'] ) && $attributes['showTitle'] ) {
 			/*
@@ -122,6 +130,9 @@ class Override {
 			if ( ! $attributes['linkLabel'] ) {
 				if ( $label ) {
 					$format = '<span class="post-navigation-link__label">' . wp_kses_post( $label ) . '</span> %link';
+					if ( $position === 'after' ) {
+						$format = '%link <span class="post-navigation-link__label">' . wp_kses_post( $label ) . '</span>';
+					}
 				}
 				$link = '%title';
 			} elseif ( isset( $attributes['linkLabel'] ) && $attributes['linkLabel'] ) {
@@ -129,7 +140,8 @@ class Override {
 				if ( $label ) {
 					$link = '<span class="post-navigation-link__label">' . wp_kses_post( $label ) . '</span> <span class="post-navigation-link__title">%title</span>';
 					// Override-starts.
-					if ( 'next' === $navigation_type ) {
+					$position = isset( $attributes['position'] ) ? $attributes['position'] : 'before';
+					if ( $position === 'after' ) {
 						$link = '<span class="post-navigation-link__title">%title</span> <span class="post-navigation-link__label">' . wp_kses_post( $label ) . '</span>';
 					}
 					// Override-ends.

--- a/theme/inc/blocks/class-override.php
+++ b/theme/inc/blocks/class-override.php
@@ -35,6 +35,7 @@ class Override {
 	 */
 	public function __construct() {
 		add_filter( 'term_links-post_tag', [ $this, 'term_links' ], 10 );
+		add_filter( 'block_type_metadata_settings', [ $this, 'override_next_post_link' ], 10, 2 );
 	}
 
 	/**
@@ -52,6 +53,111 @@ class Override {
 		$links[0] = '<i class="material-icons mdc-button__icon" aria-hidden="true">label</i>' . $links[0];
 
 		return $links;
+	}
+
+	/**
+	 * Override the next post link markup.
+	 *
+	 * @param array $settings Block register arguments.
+	 * @param array $metadata Block.json attributes.
+	 *
+	 * @return array
+	 */
+	public function override_next_post_link( $settings, $metadata ) {
+		if ( $metadata['name'] !== 'core/post-navigation-link' ) {
+			return $settings;
+		}
+
+		$settings['render_callback'] = [ $this, 'render_post_navigation_links' ];
+
+		return $settings;
+	}
+
+	/**
+	 * Override the `core/post-navigation-link` block on the server.
+	 *
+	 * Override to handle next → icon after the post title instead of before.
+	 *
+	 * @see render_block_core_post_navigation_link Search for 'override' comment in below function to know customisation.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block default content.
+	 *
+	 * @return string Returns the next or previous post link that is adjacent to the current post.
+	 */
+	public function render_post_navigation_links( $attributes, $content ) {
+		if ( ! is_singular() ) {
+			return '';
+		}
+
+		// Get the navigation type to show the proper link. Available options are `next|previous`.
+		$navigation_type = isset( $attributes['type'] ) ? $attributes['type'] : 'next';
+		// Allow only `next` and `previous` in `$navigation_type`.
+		if ( ! in_array( $navigation_type, [ 'next', 'previous' ], true ) ) {
+			return '';
+		}
+		$classes = "post-navigation-link-$navigation_type";
+		if ( isset( $attributes['textAlign'] ) ) {
+			$classes .= " has-text-align-{$attributes['textAlign']}";
+		}
+		$wrapper_attributes = get_block_wrapper_attributes( [ 'class' => $classes ] );
+		// Set default values.
+		$format = '%link';
+		$link   = 'next' === $navigation_type ? _x( 'Next', 'label for next post link', 'material-design-google' ) : _x( 'Previous', 'label for previous post link', 'material-design-google' );
+		$label  = '';
+
+		// If a custom label is provided, make this a link.
+		// `$label` is used to prepend the provided label, if we want to show the page title as well.
+		if ( isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ) {
+			$label = "{$attributes['label']}";
+			$link  = $label;
+		}
+
+		// If we want to also show the page title, make the page title a link and prepend the label.
+		if ( isset( $attributes['showTitle'] ) && $attributes['showTitle'] ) {
+			/*
+			 * If the label link option is not enabled but there is a custom label,
+			 * display the custom label as text before the linked title.
+			 */
+			if ( ! $attributes['linkLabel'] ) {
+				if ( $label ) {
+					$format = '<span class="post-navigation-link__label">' . wp_kses_post( $label ) . '</span> %link';
+				}
+				$link = '%title';
+			} elseif ( isset( $attributes['linkLabel'] ) && $attributes['linkLabel'] ) {
+				// If the label link option is enabled and there is a custom label, display it before the title.
+				if ( $label ) {
+					$link = '<span class="post-navigation-link__label">' . wp_kses_post( $label ) . '</span> <span class="post-navigation-link__title">%title</span>';
+					// Override-starts.
+					if ( 'next' === $navigation_type ) {
+						$link = '<span class="post-navigation-link__title">%title</span> <span class="post-navigation-link__label">' . wp_kses_post( $label ) . '</span>';
+					}
+					// Override-ends.
+				} else {
+					/*
+					 * If the label link option is enabled and there is no custom label,
+					 * add a colon between the label and the post title.
+					 */
+					$label = 'next' === $navigation_type ? _x( 'Next:', 'label before the title of the next post', 'material-design-google' ) : _x( 'Previous:', 'label before the title of the previous post', 'material-design-google' );
+					$link  = sprintf(
+						'<span class="post-navigation-link__label">%1$s</span> <span class="post-navigation-link__title">%2$s</span>',
+						wp_kses_post( $label ),
+						'%title'
+					);
+				}
+			}
+		}
+
+		// The dynamic portion of the function name, `$navigation_type`,
+		// refers to the type of adjacency, 'next' or 'previous'.
+		$get_link_function = "get_{$navigation_type}_post_link";
+		$content           = $get_link_function( $format, $link );
+
+		return sprintf(
+			'<div %1$s>%2$s</div>',
+			$wrapper_attributes,
+			$content
+		);
 	}
 
 }


### PR DESCRIPTION
## Summary
- Overrides `core/post-navigation-link` block to add custom position.
<!-- Please reference the issue this PR addresses. -->
Fixes #299 

| Before | After |
|--------|-------|
|  <img width="885" alt="image" src="https://user-images.githubusercontent.com/5015489/155100659-ccd1d93f-2fc5-4dc1-a647-eee228496a3c.png"> | <img width="893" alt="image" src="https://user-images.githubusercontent.com/5015489/155100584-134d975a-2df1-40bc-ae86-427610b73eae.png"> |


Demo:

https://user-images.githubusercontent.com/5015489/155152288-b2cf8053-2e5e-4531-85dd-a754ae8cdb02.mp4


## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/material-components/material-design-for-wordpress/issues) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing/engineering.md#tests).
- [x] My code follows the [Contributing Guidelines](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing.md) (updates are often made to the guidelines, check it out periodically).
