### PR TITLE
Allow user to pick m2 typography tokens; Update fse template

### DIFF
--- a/theme/assets/css/src/base/typography.css
+++ b/theme/assets/css/src/base/typography.css
@@ -26,3 +26,20 @@
 @mixin selector-typography h6, headline6, 1.25, 2, 500;
 @mixin selector-typography p, body1, 1, 1.5, 400;
 @mixin selector-typography figcaption, subtitle1, 1, 1.75, 400;
+
+/**
+ * Theme.json typography for additional class.
+ */
+@mixin selector-typography .has-headline-1-font-size, headline1, 6, 6, 300;
+@mixin selector-typography .has-headline-2-font-size, headline2, 3.75, 3.75, 300;
+@mixin selector-typography .has-headline-3-font-size, headline3, 3, 3.125, 400;
+@mixin selector-typography .has-headline-4-font-size, headline4, 2.125, 2.5, 400;
+@mixin selector-typography .has-headline-5-font-size, headline5, 1.5, 2, 400;
+@mixin selector-typography .has-headline-6-font-size, headline6, 1.25, 2, 500;
+@mixin selector-typography .has-subtitle-1-font-size, subtitle1, 1, 1.75, 400 ;
+@mixin selector-typography .has-subtitle-2-font-size, subtitle2, 0.875, 1.375, 500;
+@mixin selector-typography .has-body-1-font-size, body1, 1, 1.5, 400;
+@mixin selector-typography .has-body-2-font-size, body2, 0.875, 1.25, 400;
+@mixin selector-typography .has-caption-font-size, caption, 0.75, 1.25, 400;
+@mixin selector-typography .has-button-font-size, button, 0.875, 2.25, 500;
+@mixin selector-typography .has-overline-font-size, overline, 0.75, 2, 500;

--- a/theme/assets/css/src/components/top-app-bar.css
+++ b/theme/assets/css/src/components/top-app-bar.css
@@ -55,7 +55,8 @@
 		padding: 0;
 	}
 
-	& .site-title a {
+	& .site-title a,
+	& .wp-block-site-title a {
 		margin-right: 3px;
 		text-decoration: none;
 

--- a/theme/assets/src/block-editor/hooks.js
+++ b/theme/assets/src/block-editor/hooks.js
@@ -22,8 +22,6 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { useEffect } from '@wordpress/element';
 
 const blockClassPrefillMap = {
-	'core/site-title': 'site-title mdc-typography mdc-typography--headline6',
-	'core/post-title': 'mdc-typography mdc-typography-headline2 entry-title',
 	'core/navigation-link': 'mdc-tab',
 	'core/navigation': 'nav-wrap mdc-tab-scroller__scroll-area',
 };

--- a/theme/inc/block-editor.php
+++ b/theme/inc/block-editor.php
@@ -27,6 +27,7 @@ use MaterialDesign\Theme\Block\Override;
  */
 function setup() {
 	add_action( 'init', __NAMESPACE__ . '\\register_disable_section_meta' );
+	add_action( 'admin_init', __NAMESPACE__ . '\\force_enqueue_block_editor_assets' );
 	add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_block_editor_assets' );
 	if ( ! is_fse() ) {
 		add_action( 'body_class', __NAMESPACE__ . '\\filter_body_class' );
@@ -36,6 +37,21 @@ function setup() {
 	$blocks->init();
 
 	$overrides_block = new Override();
+}
+
+/**
+ * Force enqueue block editor assets for FSE.
+ *
+ * @return void
+ */
+function force_enqueue_block_editor_assets() {
+	global $pagenow;
+	if ( $pagenow !== 'site-editor.php' ) {
+		return;
+	}
+	// Force registration of block editor assets early so .
+
+	do_action( 'enqueue_block_editor_assets' );
 }
 
 /**

--- a/theme/inc/customizer/colors.php
+++ b/theme/inc/customizer/colors.php
@@ -294,7 +294,7 @@ function get_dark_controls() {
 /**
  * Handle updating theme.json color palette.
  *
- * @param \WP_Customize $wp_customize WP_Customize instance.
+ * @param \WP_Customize_Manager $wp_customize WP_Customize instance.
  */
 function after_save( $wp_customize ) {
 	if ( ! is_fse() ) {
@@ -379,7 +379,7 @@ function get_all_color_controls() {
 /**
  * Get user color palette.
  *
- * @param \WP_Customize $wp_customize WP_Customize instance.
+ * @param \WP_Customize_Manager $wp_customize WP_Customize instance.
  *
  * @return array
  */

--- a/theme/parts/header.html
+++ b/theme/parts/header.html
@@ -6,7 +6,7 @@
 		<div class="wp-block-group mdc-top-app-bar__row top-app-bar__header">
 			<!-- wp:group {"className":"mdc-top-app-bar__section mdc-top-app-bar__section\u002d\u002dalign-start","layout":{"type":"flex","allowOrientation":false}} -->
 			<div class="wp-block-group mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
-				<!-- wp:material/hamburger-menu {"isDrawerOpen":true} -->
+				<!-- wp:material/hamburger-menu -->
 				<div class="wp-block-material-hamburger-menu">
 					<!-- wp:material/drawer -->
 					<div class="wp-block-material-drawer">

--- a/theme/parts/subtitle.html
+++ b/theme/parts/subtitle.html
@@ -1,5 +1,3 @@
 <!-- wp:group {"layout":{"type":"flex","allowOrientation":false}} -->
-	<div class="wp-block-group">
-		<!-- wp:site-tagline {"className":"site-tagline mdc-typography--subtitle1"} /-->
-	</div>
+<div class="wp-block-group"><!-- wp:site-tagline {"fontSize":"subtitle1"} /--></div>
 <!-- /wp:group -->

--- a/theme/parts/title.html
+++ b/theme/parts/title.html
@@ -4,7 +4,7 @@
 	<div class="wp-block-group site-title__wrapper">
 		<!-- wp:group {"className":"site-title__row","layout":{"type":"flex","allowOrientation":false}} -->
 		<div class="wp-block-group site-title__row">
-			<!-- wp:site-title {"className":"site-title mdc-typography mdc-typography--headline6"} /-->
+			<!-- wp:site-title {"fontSize":"headline6"} /-->
 		</div>
 		<!-- /wp:group -->
 

--- a/theme/templates/page.html
+++ b/theme/templates/page.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"7em","right":"0px","bottom":"0px","left":"0px"}}},"layout":{"wideSize":"100vw","contentSize":"840px"}} -->
-<div class="wp-block-group" style="padding-top:7em;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:post-title {"textAlign":"left","level":1,"className":"mdc-typography mdc-typography--headline2 entry-title"} /-->
+<div class="wp-block-group" style="padding-top:7em;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:post-title {"textAlign":"left","level":1,"fontSize":"headline2"} /-->
 
 	<!-- wp:post-featured-image /--></div>
 <!-- /wp:group -->

--- a/theme/templates/single.html
+++ b/theme/templates/single.html
@@ -7,8 +7,8 @@
 	<div class="wp-block-group"></div>
 	<!-- /wp:group -->
 
-	<!-- wp:group {"className":"mdc-typography--overline","layout":{"type":"flex","flexWrap":"wrap"}} -->
-	<div class="wp-block-group mdc-typography--overline"><!-- wp:post-date {"format":"F j, Y","isLink":true} /-->
+	<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"},"fontSize":"overline"} -->
+	<div class="wp-block-group has-overline-font-size"><!-- wp:post-date {"format":"F j, Y","isLink":true} /-->
 
 		<!-- wp:paragraph -->
 		<p>⌙</p>
@@ -17,7 +17,7 @@
 		<!-- wp:post-terms {"term":"category"} /--></div>
 	<!-- /wp:group -->
 
-	<!-- wp:post-title {"textAlign":"left","level":1,"className":"mdc-typography mdc-typography--headline2 entry-title"} /-->
+	<!-- wp:post-title {"textAlign":"left","level":1,"fontSize":"headline2"} /-->
 
 	<!-- wp:post-author {"showBio":false} /--></div>
 <!-- /wp:group -->
@@ -27,8 +27,8 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"tagName":"footer","style":{"spacing":{"padding":{"top":"3rem","right":"0rem","bottom":"1.5rem","left":"0rem"}}},"layout":{"contentSize":"840px","wideSize":"100vw"}} -->
-<footer class="wp-block-group" style="padding-top:3rem;padding-right:0rem;padding-bottom:1.5rem;padding-left:0rem"><!-- wp:group {"style":{"spacing":{"padding":{"top":"0rem","right":"0rem","bottom":"0rem","left":"1rem"}}},"className":"mdc-typography\u002d\u002dcaption","layout":{"type":"flex","allowOrientation":false}} -->
-	<div class="wp-block-group mdc-typography--caption" style="padding-top:0rem;padding-right:0rem;padding-bottom:0rem;padding-left:1rem"><!-- wp:post-terms {"term":"post_tag"} /--></div>
+<footer class="wp-block-group" style="padding-top:3rem;padding-right:0rem;padding-bottom:1.5rem;padding-left:0rem"><!-- wp:group {"style":{"spacing":{"padding":{"top":"0rem","right":"0rem","bottom":"0rem","left":"1rem"}}},"layout":{"type":"flex","allowOrientation":false},"fontSize":"caption"} -->
+	<div class="wp-block-group has-caption-font-size" style="padding-top:0rem;padding-right:0rem;padding-bottom:0rem;padding-left:1rem"><!-- wp:post-terms {"term":"post_tag","fontSize":"subtitle1"} /--></div>
 	<!-- /wp:group --></footer>
 <!-- /wp:group -->
 

--- a/theme/theme.json
+++ b/theme/theme.json
@@ -127,6 +127,75 @@
     "layout": {
       "contentSize": "840px",
       "wideSize": "100vw"
+    },
+    "typography": {
+      "fontSizes": [
+        {
+          "name": "Headline 1",
+          "size": "var(--mdc-typography-headline1-font-size, 6em)",
+          "slug": "headline1"
+        },
+        {
+          "name": "Headline 2",
+          "size": "var(--mdc-typography-headline2-font-size, 3.75em)",
+          "slug": "headline2"
+        },
+        {
+          "name": "Headline 3",
+          "size": "var(--mdc-typography-headline3-font-size, 3em)",
+          "slug": "headline3"
+        },
+        {
+          "name": "Headline 4",
+          "size": "var(--mdc-typography-headline4-font-size, 2.125em)",
+          "slug": "headline4"
+        },
+        {
+          "name": "Headline 5",
+          "size": "var(--mdc-typography-headline5-font-size, 1.5em)",
+          "slug": "headline5"
+        },
+        {
+          "name": "Headline 6",
+          "size": "var(--mdc-typography-headline6-font-size, 1.25em)",
+          "slug": "headline6"
+        },
+        {
+          "name": "Body 1",
+          "size": "var(--mdc-typography-body1-font-size, 1em)",
+          "slug": "body1"
+        },
+        {
+          "name": "Body 2",
+          "size": "var(--mdc-typography-body2-font-size, 0.875em)",
+          "slug": "body2"
+        },
+        {
+          "name": "Subtitle 1",
+          "size": "var(--mdc-typography-subtitle1-font-size, 1em)",
+          "slug": "subtitle1"
+        },
+        {
+          "name": "Subtitle 2",
+          "size": "var(--mdc-typography-subtitle2-font-size, 0.875em)",
+          "slug": "subtitle2"
+        },
+        {
+          "name": "Caption",
+          "size": "var(--mdc-typography-caption-font-size, 0.75em)",
+          "slug": "caption"
+        },
+        {
+          "name": "Button",
+          "size": "var(--mdc-typography-button-font-size, 0.875em)",
+          "slug": "button"
+        },
+        {
+          "name": "Overline",
+          "size": "var(--mdc-typography-overline-font-size, 0.75em)",
+          "slug": "overline"
+        }
+      ]
     }
   }
 }

--- a/theme/theme.json
+++ b/theme/theme.json
@@ -32,6 +32,7 @@
   ],
   "settings": {
     "color": {
+      "defaultPalette": false,
       "palette": [
         {
           "slug": "primary",


### PR DESCRIPTION
## Summary
- Register m2 typography tokens in Gutenberg. 
- Allow user to pick typography tokens. 
- Remove class names added to FSE template for m2 typography.
<!-- Please reference the issue this PR addresses. -->
Dependency on PR #356

Fixes #147

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/material-components/material-design-for-wordpress/issues) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing/engineering.md#tests).
- [x] My code follows the [Contributing Guidelines](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing.md) (updates are often made to the guidelines, check it out periodically).
