### PR TITLE
Display active indicator inside drawer

### DIFF
--- a/theme/template-parts/blocks/navigation-link.php
+++ b/theme/template-parts/blocks/navigation-link.php
@@ -109,8 +109,13 @@ if ( empty( $block->context['isInDrawer'] ) ) :
 <?php else : ?>
 	<a
 		href="<?php echo esc_url( $attributes['url'] ); ?>"
-		class="mdc-list-item"
-	>
+		class="mdc-list-item
+		<?php
+		if ( $is_active ) {
+			echo 'mdc-list-item--activated';
+		}
+		?>
+	">
 		<span className="mdc-list-item__text">
 			<?php echo wp_kses_post( $attributes['label'] ); ?>
 		</span>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #235 

Adds active indicator to drawer menu items

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/material-components/material-design-for-wordpress/issues) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing/engineering.md#tests).
- [x] My code follows the [Contributing Guidelines](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing.md) (updates are often made to the guidelines, check it out periodically).
