### PR TITLE
Fix inactive tab color

### DIFF
--- a/plugin/assets/css/src/components/tab.css
+++ b/plugin/assets/css/src/components/tab.css
@@ -45,7 +45,7 @@
 }
 
 .mdc-tab .mdc-tab__text-label {
-	color: rgba(0, 0, 0, 0.6);
+	color: rgba(var(--md-sys-color-on-background-rgb, 0, 0, 0), 0.54);
 }
 
 .mdc-tab .mdc-tab__icon {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/material-components/material-design-for-wordpress/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing.md) (updates are often made to the guidelines, check it out periodically).
