### PR TITLE
Optimise plugin css

### DIFF
--- a/plugin/assets/css/src/_frontend.css
+++ b/plugin/assets/css/src/_frontend.css
@@ -1,0 +1,35 @@
+/*
+ *
+ *  Copyright 2022 Google LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+/*
+ * All Frontend CSS without importing material-components.css.
+ */
+@import "./base/variables.css";
+@import "./conf/index.css";
+@import "typography.css";
+@import "./components/contact-form.css";
+@import "./components/masonry-grid.css";
+@import "./components/card.css";
+@import "./components/core.css";
+@import "../../src/block-editor/blocks/common-posts-list/style.css";
+@import "../../src/block-editor/blocks/contact-form/inner-blocks/common/style.css";
+@import "../../src/block-editor/blocks/card/style.css";
+@import "./block/style/masonry.css";
+@import "./overrides.css";
+@import "./tokens/index.css";

--- a/plugin/assets/css/src/front-end-with-active-theme.css
+++ b/plugin/assets/css/src/front-end-with-active-theme.css
@@ -17,5 +17,5 @@
 /*
  * All Frontend CSS.
  */
-@import "material-components.css";
+@import "material-components-with-active-theme.css";
 @import "_frontend.css";

--- a/plugin/assets/css/src/material-components-with-active-theme.css
+++ b/plugin/assets/css/src/material-components-with-active-theme.css
@@ -19,7 +19,6 @@
  */
 
 @import "mixins.css";
-@import "@material/icon-button/dist/mdc.icon-button.css";
 @import "@material/layout-grid/dist/mdc.layout-grid.css";
 @import "@material/tab-bar/dist/mdc.tab-bar.css";
 @import "@material/tab-scroller/dist/mdc.tab-scroller.css";

--- a/plugin/assets/css/src/material-components-with-active-theme.css
+++ b/plugin/assets/css/src/material-components-with-active-theme.css
@@ -15,7 +15,14 @@
  */
 
 /*
- * All Frontend CSS.
+ * Required Material components when material theme is active.
  */
-@import "material-components.css";
-@import "_frontend.css";
+
+@import "mixins.css";
+@import "@material/icon-button/dist/mdc.icon-button.css";
+@import "@material/layout-grid/dist/mdc.layout-grid.css";
+@import "@material/tab-bar/dist/mdc.tab-bar.css";
+@import "@material/tab-scroller/dist/mdc.tab-scroller.css";
+@import "./components/material.css";
+@import "./components/datatable.css";
+@import "./components/tooltip.css";

--- a/plugin/assets/css/src/material-components.css
+++ b/plugin/assets/css/src/material-components.css
@@ -22,7 +22,7 @@
 @import "@material/layout-grid/dist/mdc.layout-grid.css";
 @import "@material/tab-bar/dist/mdc.tab-bar.css";
 @import "@material/tab-scroller/dist/mdc.tab-scroller.css";
-@import "components/image-card.css";
+@import "./components/image-card.css";
 @import "./components/material.css";
 @import "./components/datatable.css";
 @import "./components/text-field.css";

--- a/plugin/php/class-plugin.php
+++ b/plugin/php/class-plugin.php
@@ -263,12 +263,21 @@ class Plugin extends Plugin_Base {
 
 		wp_localize_script( 'material-front-end-js', 'materialDesign', $wp_localized_script_data );
 
-		wp_enqueue_style(
-			'material-front-end-css',
-			$this->asset_url( 'assets/css/front-end-compiled.css' ),
-			[],
-			$this->asset_version()
-		);
+		if ( self::THEME_SLUG === get_template() ) {
+			wp_enqueue_style(
+				'material-front-end-css',
+				$this->asset_url( 'assets/css/front-end-w-theme-compiled.css' ),
+				[],
+				$this->asset_version()
+			);
+		} else {
+			wp_enqueue_style(
+				'material-front-end-css',
+				$this->asset_url( 'assets/css/front-end-compiled.css' ),
+				[],
+				$this->asset_version()
+			);
+		}
 
 		/**
 		 * Enqueue material style overrides if the theme is not material.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,6 +85,14 @@ const assets = {
 			],
 		},
 		{
+			name: 'Front End with material theme ', // Remove duplicate css from theme when theme is active.
+			chunk: 'front-end-w-theme',
+			entry: [
+				'./plugin/assets/src/front-end/index.js',
+				'./plugin/assets/css/src/front-end-with-active-theme.css',
+			],
+		},
+		{
 			name: 'Admin',
 			chunk: 'admin',
 			entry: [


### PR DESCRIPTION
## Summary

Plugin loads duplicate component bundled CSS when theme is active, This removes duplicate component CSS when material theme is active by registering `front-end-w-theme` css entry point.

Saves around `109kb` uncompressed (`10.55kb` compressed) CSS for frontend.

<!-- Please reference the issue this PR addresses. -->
Screenshot: 
<details><summary>Optimized version</summary>
<p>

<img width="1341" alt="image" src="https://user-images.githubusercontent.com/5015489/186581954-b842b4f0-1827-45db-a69f-6186ef55493c.png">

</p>
</details>

<details><summary>Unoptimized</summary>
<p>

<img width="1340" alt="Screenshot 2022-08-25 at 10 53 34 AM" src="https://user-images.githubusercontent.com/5015489/186581815-2213665a-a169-463f-b786-af13d4b388f1.png">

</p>
</details>

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/material-components/material-design-for-wordpress/issues) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing/engineering.md#tests).
- [ ] My code follows the [Contributing Guidelines](https://github.com/material-components/material-design-for-wordpress/blob/main/contributing.md) (updates are often made to the guidelines, check it out periodically).
